### PR TITLE
Dockerfile and  Docker-compose Fix

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -13,4 +13,5 @@ RUN npm ci
 ADD . .
 
 EXPOSE 3000
-CMD ["npm", "run", "migrate:start:dev" ]
+
+ENTRYPOINT ["npm", "run", "migrate:start:dev" ]

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
     ports:
       - "3000:3000"
     environment:
-       - DATABASE_URL=postgresql://pgtest:pgtest@postgres:5432/pgtest?schema=public
+       - DATABASE_URL=postgresql://pgtest:pgtest@postgres:5432/pgtest?schema=public&connect_timeout=300
        - SESSION_SECRET=sessionsecret
        - NODE_ENV=development
     volumes:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -18,6 +18,8 @@ services:
       - ./tsconfig.json:/app/tsconfig.json
     networks:
       - pano
+    depends_on:
+    - postgres
   postgres:
     # match the version to the RDS
     image: postgres:14.2-alpine

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,26 +1,23 @@
 version: "3.3"
 services:
-  #   app:
-  #     build:
-  #       context: .
-  #       dockerfile: Dockerfile.dev
-  # #     entrypoint: node node_modules/.bin/remix dev
-  #     ports:
-  #       - "3000:3000"
-  #     environment:
-  #       - DATABASE_URL=postgresql://pgtest:pgtest@postgres:5432/pgtest?schema=public
-  #       - SESSION_SECRET=sessionsecret
-  #       - NODE_ENV=development
-  #     volumes:
-  #       - ./src:/app/src
-  #       - ./public:/app/public
-  #       - ./remix.config.js:/app/remix.config.js
-  #       - ./tsconfig.json:/app/tsconfig.json
-  #     links:
-  #       - postgres
-  #     depends_on:
-  #       - postgres
-
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile.dev
+    entrypoint: ["npm","run", "migrate:start:dev"]
+    ports:
+      - "3000:3000"
+    environment:
+       - DATABASE_URL=postgresql://pgtest:pgtest@postgres:5432/pgtest?schema=public
+       - SESSION_SECRET=sessionsecret
+       - NODE_ENV=development
+    volumes:
+      - ./src:/app/src
+      - ./public:/app/public
+      - ./remix.config.js:/app/remix.config.js
+      - ./tsconfig.json:/app/tsconfig.json
+    networks:
+      - pano
   postgres:
     # match the version to the RDS
     image: postgres:14.2-alpine
@@ -36,8 +33,12 @@ services:
       interval: 10s
       timeout: 3s
       retries: 5
+    networks:
+      - pano
     volumes:
       - pgdata:/var/lib/postgresql/data
 
 volumes:
   pgdata:
+networks:
+  pano:


### PR DESCRIPTION
change ENTRYPOINT to CMD, because ENTRYPOINT is preferred when you want to define an executable

change link to networks, because "  The --link flag is a deprecated, we recommend that you use user-defined networks to facilitate communication between two containers instead of using --link."

docker-compose, app service, the build step has been fixed
