### PR TITLE
feat(apps/gql): create comment resolvers

### DIFF
--- a/apps/gql/loaders/pano.ts
+++ b/apps/gql/loaders/pano.ts
@@ -3,13 +3,20 @@ import { type Connection } from "@kampus/gql-utils/connection";
 import { type Post } from "@kampus/prisma";
 
 import { type Clients } from "~/clients";
-import { type PanoPost, type PanoPostConnection } from "~/schema/types.generated";
+import {
+  type PanoComment,
+  type PanoCommentConnection,
+  type PanoPost,
+  type PanoPostConnection,
+} from "~/schema/types.generated";
+import { type Comment } from ".prisma/client";
 
 export type PanoLoaders = ReturnType<typeof createPanoLoaders>;
 
 export const createPanoLoaders = (clients: Clients) => {
   return {
     post: createPanoPostLoaders(clients),
+    comment: createPanoCommentLoaders(clients),
   };
 };
 
@@ -35,11 +42,40 @@ const createPanoPostLoaders = ({ prisma }: Clients) => {
   };
 };
 
+const createPanoCommentLoaders = ({ prisma }: Clients) => {
+  const cacheCommentConnection = (connections: Connection<Comment>[]) => {
+    connections.forEach((connection) => {
+      connection.nodes.forEach(cacheComment);
+    });
+  };
+
+  const cacheComment = (comment: Comment) => {
+    byID.prime(comment.id, comment);
+  };
+
+  const byID = createPrismaLoader(prisma.comment, "id");
+  const byParentID = createPrismaConnectionLoader(
+    prisma.comment,
+    "parentID",
+    cacheCommentConnection
+  );
+  const byPostID = createPrismaConnectionLoader(prisma.comment, "postID", cacheCommentConnection);
+  const all = createPrismaConnectionLoader(prisma.comment, null);
+
+  return {
+    byID,
+    byParentID,
+    byPostID,
+    all,
+  };
+};
+
 export const transformPanoPost = (post: Post) => {
   return {
     ...post,
     __typename: "PanoPost",
     owner: null,
+    comments: null,
     createdAt: post.createdAt.toISOString(),
   } satisfies PanoPost;
 };
@@ -58,4 +94,32 @@ export const transformPanoPostConnection = (connection: Connection<Post>) => {
     },
     totalCount: connection.totalCount,
   } satisfies PanoPostConnection;
+};
+
+export const transformPanoComment = (comment: Comment) => {
+  return {
+    ...comment,
+    __typename: "PanoComment",
+    owner: null,
+    parent: null,
+    post: null,
+    comments: null,
+    createdAt: comment.createdAt.toISOString(),
+  } satisfies PanoComment;
+};
+
+export const transformPanoCommentConnection = (connection: Connection<Comment>) => {
+  return {
+    nodes: connection.nodes.map(transformPanoComment),
+    edges: connection.edges.map((edge) => ({
+      ...edge,
+      node: transformPanoComment(edge.node),
+    })),
+    pageInfo: {
+      ...connection.pageInfo,
+      endCursor: connection.pageInfo.endCursor ?? null,
+      startCursor: connection.pageInfo.startCursor ?? null,
+    },
+    totalCount: connection.totalCount,
+  } satisfies PanoCommentConnection;
 };

--- a/apps/gql/loaders/pano.ts
+++ b/apps/gql/loaders/pano.ts
@@ -1,6 +1,6 @@
 import { createPrismaConnectionLoader, createPrismaLoader } from "@kampus/gql-utils";
 import { type Connection } from "@kampus/gql-utils/connection";
-import { type Post } from "@kampus/prisma";
+import { type Comment, type Post } from "@kampus/prisma";
 
 import { type Clients } from "~/clients";
 import {
@@ -9,7 +9,6 @@ import {
   type PanoPost,
   type PanoPostConnection,
 } from "~/schema/types.generated";
-import { type Comment } from ".prisma/client";
 
 export type PanoLoaders = ReturnType<typeof createPanoLoaders>;
 

--- a/apps/gql/schema/resolvers/index.ts
+++ b/apps/gql/schema/resolvers/index.ts
@@ -47,6 +47,8 @@ export const resolvers = {
           return transformSozlukTerm(await loaders.sozluk.term.load(id.value));
         case "PanoPost":
           return transformPanoPost(await loaders.pano.post.byID.load(id.value));
+        case "PanoComment":
+          return transformPanoComment(await loaders.pano.comment.byID.load(id.value));
         default:
           return assertNever(id.type);
       }

--- a/apps/gql/schema/schema.graphql
+++ b/apps/gql/schema/schema.graphql
@@ -92,6 +92,12 @@ type PanoPost implements Node {
   content: String
   createdAt: DateTime!
   owner: User
+  comments(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): PanoCommentConnection
 }
 
 type PanoPostConnection {
@@ -104,4 +110,31 @@ type PanoPostConnection {
 type PanoPostEdge {
   cursor: String!
   node: PanoPost
+}
+
+type PanoComment implements Node {
+  id: ID!
+  content: String!
+  owner: User
+  post: PanoPost
+  parent: PanoComment
+  comments(
+    after: String
+    before: String
+    first: Int
+    last: Int
+  ): PanoCommentConnection
+  createdAt: DateTime!
+}
+
+type PanoCommentConnection {
+  nodes: [PanoComment]
+  edges: [PanoCommentEdge]
+  pageInfo: PageInfo!
+  totalCount: Int!
+}
+
+type PanoCommentEdge {
+  cursor: String!
+  node: PanoComment
 }

--- a/apps/gql/schema/types.generated.ts
+++ b/apps/gql/schema/types.generated.ts
@@ -37,14 +37,54 @@ export type PageInfo = {
   startCursor: Maybe<Scalars["String"]["output"]>;
 };
 
+export type PanoComment = Node & {
+  __typename?: "PanoComment";
+  comments: Maybe<PanoCommentConnection>;
+  content: Scalars["String"]["output"];
+  createdAt: Scalars["DateTime"]["output"];
+  id: Scalars["ID"]["output"];
+  owner: Maybe<User>;
+  parent: Maybe<PanoComment>;
+  post: Maybe<PanoPost>;
+};
+
+export type PanoCommentCommentsArgs = {
+  after: InputMaybe<Scalars["String"]["input"]>;
+  before: InputMaybe<Scalars["String"]["input"]>;
+  first: InputMaybe<Scalars["Int"]["input"]>;
+  last: InputMaybe<Scalars["Int"]["input"]>;
+};
+
+export type PanoCommentConnection = {
+  __typename?: "PanoCommentConnection";
+  edges: Maybe<Array<Maybe<PanoCommentEdge>>>;
+  nodes: Maybe<Array<Maybe<PanoComment>>>;
+  pageInfo: PageInfo;
+  totalCount: Scalars["Int"]["output"];
+};
+
+export type PanoCommentEdge = {
+  __typename?: "PanoCommentEdge";
+  cursor: Scalars["String"]["output"];
+  node: Maybe<PanoComment>;
+};
+
 export type PanoPost = Node & {
   __typename?: "PanoPost";
+  comments: Maybe<PanoCommentConnection>;
   content: Maybe<Scalars["String"]["output"]>;
   createdAt: Scalars["DateTime"]["output"];
   id: Scalars["ID"]["output"];
   owner: Maybe<User>;
   title: Scalars["String"]["output"];
   url: Maybe<Scalars["String"]["output"]>;
+};
+
+export type PanoPostCommentsArgs = {
+  after: InputMaybe<Scalars["String"]["input"]>;
+  before: InputMaybe<Scalars["String"]["input"]>;
+  first: InputMaybe<Scalars["Int"]["input"]>;
+  last: InputMaybe<Scalars["Int"]["input"]>;
 };
 
 export type PanoPostConnection = {
@@ -251,6 +291,7 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 /** Mapping of interface types */
 export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = ResolversObject<{
   Node:
+    | (PanoComment & { __typename: "PanoComment" })
     | (PanoPost & { __typename: "PanoPost" })
     | (SozlukTerm & { __typename: "SozlukTerm" })
     | (User & { __typename: "User" });
@@ -265,6 +306,9 @@ export type ResolversTypes = ResolversObject<{
   Int: ResolverTypeWrapper<Scalars["Int"]["output"]>;
   Node: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>["Node"]>;
   PageInfo: ResolverTypeWrapper<PageInfo>;
+  PanoComment: ResolverTypeWrapper<PanoComment>;
+  PanoCommentConnection: ResolverTypeWrapper<PanoCommentConnection>;
+  PanoCommentEdge: ResolverTypeWrapper<PanoCommentEdge>;
   PanoPost: ResolverTypeWrapper<PanoPost>;
   PanoPostConnection: ResolverTypeWrapper<PanoPostConnection>;
   PanoPostEdge: ResolverTypeWrapper<PanoPostEdge>;
@@ -289,6 +333,9 @@ export type ResolversParentTypes = ResolversObject<{
   Int: Scalars["Int"]["output"];
   Node: ResolversInterfaceTypes<ResolversParentTypes>["Node"];
   PageInfo: PageInfo;
+  PanoComment: PanoComment;
+  PanoCommentConnection: PanoCommentConnection;
+  PanoCommentEdge: PanoCommentEdge;
   PanoPost: PanoPost;
   PanoPostConnection: PanoPostConnection;
   PanoPostEdge: PanoPostEdge;
@@ -316,7 +363,11 @@ export type NodeResolvers<
   ContextType = KampusGQLContext,
   ParentType extends ResolversParentTypes["Node"] = ResolversParentTypes["Node"]
 > = ResolversObject<{
-  __resolveType?: TypeResolveFn<"PanoPost" | "SozlukTerm" | "User", ParentType, ContextType>;
+  __resolveType?: TypeResolveFn<
+    "PanoComment" | "PanoPost" | "SozlukTerm" | "User",
+    ParentType,
+    ContextType
+  >;
 }>;
 
 export type PageInfoResolvers<
@@ -330,10 +381,55 @@ export type PageInfoResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type PanoCommentResolvers<
+  ContextType = KampusGQLContext,
+  ParentType extends ResolversParentTypes["PanoComment"] = ResolversParentTypes["PanoComment"]
+> = ResolversObject<{
+  comments: Resolver<
+    Maybe<ResolversTypes["PanoCommentConnection"]>,
+    ParentType,
+    ContextType,
+    Partial<PanoCommentCommentsArgs>
+  >;
+  content: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  createdAt: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
+  id: Resolver<ResolversTypes["ID"], ParentType, ContextType>;
+  owner: Resolver<Maybe<ResolversTypes["User"]>, ParentType, ContextType>;
+  parent: Resolver<Maybe<ResolversTypes["PanoComment"]>, ParentType, ContextType>;
+  post: Resolver<Maybe<ResolversTypes["PanoPost"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type PanoCommentConnectionResolvers<
+  ContextType = KampusGQLContext,
+  ParentType extends ResolversParentTypes["PanoCommentConnection"] = ResolversParentTypes["PanoCommentConnection"]
+> = ResolversObject<{
+  edges: Resolver<Maybe<Array<Maybe<ResolversTypes["PanoCommentEdge"]>>>, ParentType, ContextType>;
+  nodes: Resolver<Maybe<Array<Maybe<ResolversTypes["PanoComment"]>>>, ParentType, ContextType>;
+  pageInfo: Resolver<ResolversTypes["PageInfo"], ParentType, ContextType>;
+  totalCount: Resolver<ResolversTypes["Int"], ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
+export type PanoCommentEdgeResolvers<
+  ContextType = KampusGQLContext,
+  ParentType extends ResolversParentTypes["PanoCommentEdge"] = ResolversParentTypes["PanoCommentEdge"]
+> = ResolversObject<{
+  cursor: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  node: Resolver<Maybe<ResolversTypes["PanoComment"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type PanoPostResolvers<
   ContextType = KampusGQLContext,
   ParentType extends ResolversParentTypes["PanoPost"] = ResolversParentTypes["PanoPost"]
 > = ResolversObject<{
+  comments: Resolver<
+    Maybe<ResolversTypes["PanoCommentConnection"]>,
+    ParentType,
+    ContextType,
+    Partial<PanoPostCommentsArgs>
+  >;
   content: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
   createdAt: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
   id: Resolver<ResolversTypes["ID"], ParentType, ContextType>;
@@ -482,6 +578,9 @@ export type Resolvers<ContextType = KampusGQLContext> = ResolversObject<{
   DateTime: GraphQLScalarType;
   Node: NodeResolvers<ContextType>;
   PageInfo: PageInfoResolvers<ContextType>;
+  PanoComment: PanoCommentResolvers<ContextType>;
+  PanoCommentConnection: PanoCommentConnectionResolvers<ContextType>;
+  PanoCommentEdge: PanoCommentEdgeResolvers<ContextType>;
   PanoPost: PanoPostResolvers<ContextType>;
   PanoPostConnection: PanoPostConnectionResolvers<ContextType>;
   PanoPostEdge: PanoPostEdgeResolvers<ContextType>;


### PR DESCRIPTION
# Description

comment resolver implementation

### Checklist

- [x] discord username: `furkang`
- [x] Closes #513
- [x] PR must be created for an issue from issues under "In progress" column from [our project board](https://github.com/orgs/kamp-us/projects/2/views/1).
- [x] A descriptive and understandable title: The PR title should clearly describe the nature and purpose of the changes. The PR title should be the first thing displayed when the PR is opened. And it should follow the semantic commit rules, and should include the app/package/service name in the title. For example, a title like "docs(@kampus-apps/pano): Add README.md" can be used.
- [x] Related file selection: Only relevant files should be touched and no other files should be affected.
- [x] I ran `npx turbo run` at the root of the repository, and build was successful.
- [x] I installed the npm packages using `npm install --save-exact <package>` so my package is pinned to a specific npm version. Leave empty if no package was installed. Leave empty if no package was installed with this PR.

### How were these changes tested?

```graphql
query PanoPostCommentQuery($id: ID = "1", $first: Int = 1) {
  pano {
    post(id: $id) {
      id
      title
      comments(first: $first) {
        nodes {
          id
          content
        }
      }
    }
  }
}
```