### PR TITLE
feat(apps/pasaport): setup relay & gql

### DIFF
--- a/apps/kampus/app/layout.tsx
+++ b/apps/kampus/app/layout.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode } from "react";
 import { Inter } from "next/font/google";
 
-import { RelayEnvironmentProvider } from "~/features/relay/RelayEnvironmentProvider";
+import { RelayEnvironmentProvider } from "@kampus/relay";
 
 import "./globals.css";
 

--- a/apps/pasaport/.env.example
+++ b/apps/pasaport/.env.example
@@ -9,3 +9,4 @@ DISCORD_SECRET=''
 TWITCH_ID=''
 TWITCH_SECRET=''
 NEXTAUTH_SECRET='Example'
+GQL_URL="http://localhost:3001/graphql"

--- a/apps/pasaport/app/layout.tsx
+++ b/apps/pasaport/app/layout.tsx
@@ -1,7 +1,11 @@
+import { RelayEnvironmentProvider } from "@kampus/relay";
+
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <RelayEnvironmentProvider>{children}</RelayEnvironmentProvider>
+      </body>
     </html>
   );
 }

--- a/apps/pasaport/env.ts
+++ b/apps/pasaport/env.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 export const env = parseEnv(process.env, {
   NODE_ENV: z.enum(["development", "test", "production"]),
   NEXTAUTH_URL: z.string().url().default("http://sozluk.local.kamp.us:3000/auth"),
+  GQL_URL: z.string().url().default("http://localhost:3001/graphql"),
   DATABASE_URL: z
     .string()
     .url()

--- a/apps/pasaport/package.json
+++ b/apps/pasaport/package.json
@@ -22,6 +22,9 @@
     "vitest-mock-extended": "1.1.3"
   },
   "dependencies": {
+    "@kampus/relay": "*",
+    "react-relay": "15.0.0",
+    "relay-compiler": "15.0.0",
     "znv": "0.3.2",
     "zod": "3.21.4",
     "@kampus/email": "*",

--- a/apps/pasaport/package.json
+++ b/apps/pasaport/package.json
@@ -7,6 +7,7 @@
     "dev": "next dev",
     "start": "next start",
     "lint": "next lint",
+    "relay": "relay-compiler",
     "test": "vitest",
     "test:ui": "vitest --ui",
     "test:cov": "vitest --coverage"

--- a/apps/pasaport/relay.config.js
+++ b/apps/pasaport/relay.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  src: "./",
+  language: "typescript",
+  schema: "../gql/schema/schema.graphql",
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,14 @@
         "@types/react-relay": "14.1.4"
       }
     },
+    "apps/kampus/node_modules/relay-compiler": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-15.0.0.tgz",
+      "integrity": "sha512-19gIIdrVe/lk7Dkz/hqxpBd54bBDWAKG+kR5ael+xznJPdjlr/rlAmh5Tqi6Mgf/wiEQGdtKiZqeNdOW2/wVRw==",
+      "bin": {
+        "relay-compiler": "cli.js"
+      }
+    },
     "apps/pasaport": {
       "name": "@kampus/pasaport",
       "version": "0.0.0",
@@ -103,6 +111,14 @@
         "vite-tsconfig-paths": "4.2.0",
         "vitest": "0.32.2",
         "vitest-mock-extended": "1.1.3"
+      }
+    },
+    "apps/pasaport/node_modules/relay-compiler": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-15.0.0.tgz",
+      "integrity": "sha512-19gIIdrVe/lk7Dkz/hqxpBd54bBDWAKG+kR5ael+xznJPdjlr/rlAmh5Tqi6Mgf/wiEQGdtKiZqeNdOW2/wVRw==",
+      "bin": {
+        "relay-compiler": "cli.js"
       }
     },
     "apps/ui": {
@@ -21318,14 +21334,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
-      }
-    },
-    "node_modules/relay-compiler": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-15.0.0.tgz",
-      "integrity": "sha512-19gIIdrVe/lk7Dkz/hqxpBd54bBDWAKG+kR5ael+xznJPdjlr/rlAmh5Tqi6Mgf/wiEQGdtKiZqeNdOW2/wVRw==",
-      "bin": {
-        "relay-compiler": "cli.js"
       }
     },
     "node_modules/relay-runtime": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,20 +85,15 @@
         "@types/react-relay": "14.1.4"
       }
     },
-    "apps/kampus/node_modules/relay-compiler": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-15.0.0.tgz",
-      "integrity": "sha512-19gIIdrVe/lk7Dkz/hqxpBd54bBDWAKG+kR5ael+xznJPdjlr/rlAmh5Tqi6Mgf/wiEQGdtKiZqeNdOW2/wVRw==",
-      "bin": {
-        "relay-compiler": "cli.js"
-      }
-    },
     "apps/pasaport": {
       "name": "@kampus/pasaport",
       "version": "0.0.0",
       "dependencies": {
         "@kampus/email": "*",
         "@kampus/next-auth": "*",
+        "@kampus/relay": "*",
+        "react-relay": "15.0.0",
+        "relay-compiler": "15.0.0",
         "znv": "0.3.2",
         "zod": "3.21.4"
       },
@@ -21325,6 +21320,14 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/relay-compiler": {
+      "version": "15.0.0",
+      "resolved": "https://registry.npmjs.org/relay-compiler/-/relay-compiler-15.0.0.tgz",
+      "integrity": "sha512-19gIIdrVe/lk7Dkz/hqxpBd54bBDWAKG+kR5ael+xznJPdjlr/rlAmh5Tqi6Mgf/wiEQGdtKiZqeNdOW2/wVRw==",
+      "bin": {
+        "relay-compiler": "cli.js"
+      }
+    },
     "node_modules/relay-runtime": {
       "version": "12.0.0",
       "resolved": "https://registry.npmjs.org/relay-runtime/-/relay-runtime-12.0.0.tgz",
@@ -25119,6 +25122,10 @@
       "devDependencies": {
         "@types/react-relay": "14.1.4",
         "@types/relay-runtime": "14.1.10"
+      },
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     },
     "packages/relay/node_modules/relay-runtime": {

--- a/packages/relay/index.ts
+++ b/packages/relay/index.ts
@@ -1,3 +1,4 @@
 export * from "./environment";
 export * from "./load-serializable-query";
 export * from "./use-serializable-preloaded-query";
+export * from "./relay-environment-provider.ts";

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -17,5 +17,9 @@
   "devDependencies": {
     "@types/react-relay": "14.1.4",
     "@types/relay-runtime": "14.1.10"
+  },
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
   }
 }

--- a/packages/relay/relay-environment-provider.tsx
+++ b/packages/relay/relay-environment-provider.tsx
@@ -3,7 +3,7 @@
 import { type PropsWithChildren } from "react";
 import { RelayEnvironmentProvider as ReactRelayEnvironmentProvider } from "react-relay";
 
-import { getCurrentEnvironment } from "@kampus/relay";
+import { getCurrentEnvironment } from "./environment";
 
 export const RelayEnvironmentProvider = ({ children }: PropsWithChildren) => {
   const environment = getCurrentEnvironment();


### PR DESCRIPTION
# Description

Sets up relay for pasaport app

### Checklist

- [x] discord username: `ketcapwastaken`
- [x] I ran `npx turbo run` at the root of the repository, and build was successful.
- [x] I installed the npm packages using `npm install --save-exact <package>` so my package is pinned to a specific npm version. Leave empty if no package was installed. Leave empty if no package was installed with this PR.

### How were these changes tested?

Please describe the tests you did to test the changes you made. Please also specify your test configuration.
