### PR TITLE
fix(apps/gql): add PostUpvote resolver & update PostUpvote graphql fields

### DIFF
--- a/apps/gql/loaders/pano.ts
+++ b/apps/gql/loaders/pano.ts
@@ -48,10 +48,11 @@ const createPanoPostLoaders = ({ prisma }: Clients) => {
 };
 
 const createPanoUpvoteLoaders = ({ prisma }: Clients) => {
+  const byID = createPrismaLoader(prisma.upvote, "id");
   const countByPostID = createPrismaCountLoader(prisma.upvote, "postID");
   const countByCommentID = createPrismaCountLoader(prisma.commentUpvote, "commentID");
 
-  return { countByPostID, countByCommentID };
+  return { byID, countByPostID, countByCommentID };
 };
 
 const createPanoCommentLoaders = ({ prisma }: Clients) => {
@@ -148,5 +149,7 @@ export const transformPostUpvote = (upvote: Upvote) => {
   return {
     ...upvote,
     __typename: "PostUpvote",
+    post: null,
+    owner: null,
   } satisfies PostUpvote;
 };

--- a/apps/gql/schema/resolvers/index.ts
+++ b/apps/gql/schema/resolvers/index.ts
@@ -238,6 +238,19 @@ export const resolvers = {
     pageInfo: (connection) => transformPageInfo("PanoComment", connection.pageInfo),
     totalCount: (connection) => connection.totalCount,
   },
+  PostUpvote: {
+    id: (upvote) => stringify("PostUpvote", upvote.id),
+    post: async (upvote, _, { loaders }) => {
+      const model = await loaders.pano.upvote.byID.load(upvote.id);
+      const post = await loaders.pano.post.byID.load(model.postID);
+      return transformPanoPost(post);
+    },
+    owner: async (upvote, _, { loaders }) => {
+      const model = await loaders.pano.upvote.byID.load(upvote.id);
+      const user = await loaders.user.byID.load(model.userID);
+      return transformUser(user);
+    },
+  },
 
   CreatePanoPostPayload: {}, // union
   UpdatePanoPostPayload: {}, // union

--- a/apps/gql/schema/schema.graphql
+++ b/apps/gql/schema/schema.graphql
@@ -160,8 +160,8 @@ type PanoCommentEdge {
 
 type PostUpvote {
   id: ID!
-  postID: String!
-  userID: String!
+  post: PanoPost
+  owner: User
 }
 
 type Mutation {

--- a/apps/gql/schema/types.generated.ts
+++ b/apps/gql/schema/types.generated.ts
@@ -206,8 +206,8 @@ export type PanoQueryPostsArgs = {
 export type PostUpvote = {
   __typename?: "PostUpvote";
   id: Scalars["ID"]["output"];
-  postID: Scalars["String"]["output"];
-  userID: Scalars["String"]["output"];
+  owner: Maybe<User>;
+  post: Maybe<PanoPost>;
 };
 
 export type Query = {
@@ -839,8 +839,8 @@ export type PostUpvoteResolvers<
   ParentType extends ResolversParentTypes["PostUpvote"] = ResolversParentTypes["PostUpvote"]
 > = ResolversObject<{
   id: Resolver<ResolversTypes["ID"], ParentType, ContextType>;
-  postID: Resolver<ResolversTypes["String"], ParentType, ContextType>;
-  userID: Resolver<ResolversTypes["String"], ParentType, ContextType>;
+  owner: Resolver<Maybe<ResolversTypes["User"]>, ParentType, ContextType>;
+  post: Resolver<Maybe<ResolversTypes["PanoPost"]>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 


### PR DESCRIPTION
# Description
This pr includes adding missing PostUpvote to resolvers object and replacing postID and userID fields in PostUpvote gql type with post and owner.