### PR TITLE
feat(apps/gql): change mutation payload types

### DIFF
--- a/apps/gql/schema/schema.graphql
+++ b/apps/gql/schema/schema.graphql
@@ -177,13 +177,20 @@ type Mutation {
   removePostUpvote(input: RemovePostUpvoteInput!): RemovePostUpvotePayload
 }
 
+# Pano post mutations
+
+union PanoPostError = NotAuthorized | InvalidInput
+
 input CreatePanoPostInput {
   title: String!
   content: String
   url: String
 }
 
-union CreatePanoPostPayload = PanoPost | NotAuthorized | InvalidInput
+type CreatePanoPostPayload {
+  edge: PanoPostEdge
+  error: PanoPostError
+}
 
 input UpdatePanoPostInput {
   id: ID!
@@ -192,15 +199,23 @@ input UpdatePanoPostInput {
   url: String
 }
 
-union UpdatePanoPostPayload = PanoPost | NotAuthorized | InvalidInput
+type UpdatePanoPostPayload {
+  edge: PanoPostEdge
+  error: PanoPostError
+}
 
 input RemovePanoPostInput {
   id: ID!
 }
 
-union RemovePanoPostPayload = PanoPost | NotAuthorized | InvalidInput
+type RemovePanoPostPayload {
+  edge: PanoPostEdge
+  error: PanoPostError
+}
 
-union CreatePanoCommentPayload = PanoComment | NotAuthorized | InvalidInput
+# Pano comment mutations
+
+union PanoCommentError = NotAuthorized | InvalidInput
 
 input CreatePanoCommentInput {
   content: String!
@@ -208,27 +223,48 @@ input CreatePanoCommentInput {
   parentID: String
 }
 
-union UpdatePanoCommentPayload = PanoComment | NotAuthorized | InvalidInput
+type CreatePanoCommentPayload {
+  edge: PanoCommentEdge
+  error: PanoCommentError
+}
 
 input UpdatePanoCommentInput {
   id: ID!
   content: String!
 }
 
-union RemovePanoCommentPayload = PanoComment | NotAuthorized | InvalidInput
+type UpdatePanoCommentPayload {
+  edge: PanoCommentEdge
+  error: PanoCommentError
+}
 
 input RemovePanoCommentInput {
   id: ID!
 }
 
+type RemovePanoCommentPayload {
+  edge: PanoCommentEdge
+  error: PanoCommentError
+}
+
+# Pano post upvote mutations
+
+union PostUpvoteError = NotAuthorized | InvalidInput
+
 input CreatePostUpvoteInput {
   postID: String!
 }
 
-union CreatePostUpvotePayload = PostUpvote | NotAuthorized | InvalidInput
+type CreatePostUpvotePayload {
+  node: PostUpvote
+  error: PostUpvoteError
+}
 
 input RemovePostUpvoteInput {
   postID: String!
 }
 
-union RemovePostUpvotePayload = PostUpvote | NotAuthorized | InvalidInput
+type RemovePostUpvotePayload {
+  node: PostUpvote
+  error: PostUpvoteError
+}

--- a/apps/gql/schema/types.generated.ts
+++ b/apps/gql/schema/types.generated.ts
@@ -13,6 +13,7 @@ export type MakeEmpty<T extends { [key: string]: unknown }, K extends keyof T> =
 export type Incremental<T> =
   | T
   | { [P in keyof T]?: P extends " $fragmentName" | "__typename" ? T[P] : never };
+export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 export type RequireFields<T, K extends keyof T> = Omit<T, K> & { [P in K]-?: NonNullable<T[P]> };
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
@@ -36,7 +37,11 @@ export type CreatePanoCommentInput = {
   postID: Scalars["String"]["input"];
 };
 
-export type CreatePanoCommentPayload = InvalidInput | NotAuthorized | PanoComment;
+export type CreatePanoCommentPayload = {
+  __typename?: "CreatePanoCommentPayload";
+  edge: Maybe<PanoCommentEdge>;
+  error: Maybe<PanoCommentError>;
+};
 
 export type CreatePanoPostInput = {
   content: InputMaybe<Scalars["String"]["input"]>;
@@ -44,13 +49,21 @@ export type CreatePanoPostInput = {
   url: InputMaybe<Scalars["String"]["input"]>;
 };
 
-export type CreatePanoPostPayload = InvalidInput | NotAuthorized | PanoPost;
+export type CreatePanoPostPayload = {
+  __typename?: "CreatePanoPostPayload";
+  edge: Maybe<PanoPostEdge>;
+  error: Maybe<PanoPostError>;
+};
 
 export type CreatePostUpvoteInput = {
   postID: Scalars["String"]["input"];
 };
 
-export type CreatePostUpvotePayload = InvalidInput | NotAuthorized | PostUpvote;
+export type CreatePostUpvotePayload = {
+  __typename?: "CreatePostUpvotePayload";
+  error: Maybe<PostUpvoteError>;
+  node: Maybe<PostUpvote>;
+};
 
 export type InvalidInput = UserError & {
   __typename?: "InvalidInput";
@@ -152,6 +165,8 @@ export type PanoCommentEdge = {
   node: Maybe<PanoComment>;
 };
 
+export type PanoCommentError = InvalidInput | NotAuthorized;
+
 export type PanoPost = Node & {
   __typename?: "PanoPost";
   commentCount: Maybe<Scalars["Int"]["output"]>;
@@ -187,6 +202,8 @@ export type PanoPostEdge = {
   node: Maybe<PanoPost>;
 };
 
+export type PanoPostError = InvalidInput | NotAuthorized;
+
 export type PanoPostFilter = "ACTIVE" | "ALL" | "HOT" | "LIKED" | "SELF";
 
 export type PanoQuery = {
@@ -210,6 +227,8 @@ export type PostUpvote = {
   post: Maybe<PanoPost>;
 };
 
+export type PostUpvoteError = InvalidInput | NotAuthorized;
+
 export type Query = {
   __typename?: "Query";
   node: Maybe<Node>;
@@ -232,19 +251,31 @@ export type RemovePanoCommentInput = {
   id: Scalars["ID"]["input"];
 };
 
-export type RemovePanoCommentPayload = InvalidInput | NotAuthorized | PanoComment;
+export type RemovePanoCommentPayload = {
+  __typename?: "RemovePanoCommentPayload";
+  edge: Maybe<PanoCommentEdge>;
+  error: Maybe<PanoCommentError>;
+};
 
 export type RemovePanoPostInput = {
   id: Scalars["ID"]["input"];
 };
 
-export type RemovePanoPostPayload = InvalidInput | NotAuthorized | PanoPost;
+export type RemovePanoPostPayload = {
+  __typename?: "RemovePanoPostPayload";
+  edge: Maybe<PanoPostEdge>;
+  error: Maybe<PanoPostError>;
+};
 
 export type RemovePostUpvoteInput = {
   postID: Scalars["String"]["input"];
 };
 
-export type RemovePostUpvotePayload = InvalidInput | NotAuthorized | PostUpvote;
+export type RemovePostUpvotePayload = {
+  __typename?: "RemovePostUpvotePayload";
+  error: Maybe<PostUpvoteError>;
+  node: Maybe<PostUpvote>;
+};
 
 export type SozlukQuery = {
   __typename?: "SozlukQuery";
@@ -296,7 +327,11 @@ export type UpdatePanoCommentInput = {
   id: Scalars["ID"]["input"];
 };
 
-export type UpdatePanoCommentPayload = InvalidInput | NotAuthorized | PanoComment;
+export type UpdatePanoCommentPayload = {
+  __typename?: "UpdatePanoCommentPayload";
+  edge: Maybe<PanoCommentEdge>;
+  error: Maybe<PanoCommentError>;
+};
 
 export type UpdatePanoPostInput = {
   content: InputMaybe<Scalars["String"]["input"]>;
@@ -305,7 +340,11 @@ export type UpdatePanoPostInput = {
   url: InputMaybe<Scalars["String"]["input"]>;
 };
 
-export type UpdatePanoPostPayload = InvalidInput | NotAuthorized | PanoPost;
+export type UpdatePanoPostPayload = {
+  __typename?: "UpdatePanoPostPayload";
+  edge: Maybe<PanoPostEdge>;
+  error: Maybe<PanoPostError>;
+};
 
 export type User = Actor &
   Node & {
@@ -429,38 +468,15 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 
 /** Mapping of union types */
 export type ResolversUnionTypes<RefType extends Record<string, unknown>> = ResolversObject<{
-  CreatePanoCommentPayload:
+  PanoCommentError:
     | (InvalidInput & { __typename: "InvalidInput" })
-    | (NotAuthorized & { __typename: "NotAuthorized" })
-    | (PanoComment & { __typename: "PanoComment" });
-  CreatePanoPostPayload:
+    | (NotAuthorized & { __typename: "NotAuthorized" });
+  PanoPostError:
     | (InvalidInput & { __typename: "InvalidInput" })
-    | (NotAuthorized & { __typename: "NotAuthorized" })
-    | (PanoPost & { __typename: "PanoPost" });
-  CreatePostUpvotePayload:
+    | (NotAuthorized & { __typename: "NotAuthorized" });
+  PostUpvoteError:
     | (InvalidInput & { __typename: "InvalidInput" })
-    | (NotAuthorized & { __typename: "NotAuthorized" })
-    | (PostUpvote & { __typename: "PostUpvote" });
-  RemovePanoCommentPayload:
-    | (InvalidInput & { __typename: "InvalidInput" })
-    | (NotAuthorized & { __typename: "NotAuthorized" })
-    | (PanoComment & { __typename: "PanoComment" });
-  RemovePanoPostPayload:
-    | (InvalidInput & { __typename: "InvalidInput" })
-    | (NotAuthorized & { __typename: "NotAuthorized" })
-    | (PanoPost & { __typename: "PanoPost" });
-  RemovePostUpvotePayload:
-    | (InvalidInput & { __typename: "InvalidInput" })
-    | (NotAuthorized & { __typename: "NotAuthorized" })
-    | (PostUpvote & { __typename: "PostUpvote" });
-  UpdatePanoCommentPayload:
-    | (InvalidInput & { __typename: "InvalidInput" })
-    | (NotAuthorized & { __typename: "NotAuthorized" })
-    | (PanoComment & { __typename: "PanoComment" });
-  UpdatePanoPostPayload:
-    | (InvalidInput & { __typename: "InvalidInput" })
-    | (NotAuthorized & { __typename: "NotAuthorized" })
-    | (PanoPost & { __typename: "PanoPost" });
+    | (NotAuthorized & { __typename: "NotAuthorized" });
 }>;
 
 /** Mapping of interface types */
@@ -482,15 +498,15 @@ export type ResolversTypes = ResolversObject<{
   Boolean: ResolverTypeWrapper<Scalars["Boolean"]["output"]>;
   CreatePanoCommentInput: CreatePanoCommentInput;
   CreatePanoCommentPayload: ResolverTypeWrapper<
-    ResolversUnionTypes<ResolversTypes>["CreatePanoCommentPayload"]
+    Omit<CreatePanoCommentPayload, "error"> & { error: Maybe<ResolversTypes["PanoCommentError"]> }
   >;
   CreatePanoPostInput: CreatePanoPostInput;
   CreatePanoPostPayload: ResolverTypeWrapper<
-    ResolversUnionTypes<ResolversTypes>["CreatePanoPostPayload"]
+    Omit<CreatePanoPostPayload, "error"> & { error: Maybe<ResolversTypes["PanoPostError"]> }
   >;
   CreatePostUpvoteInput: CreatePostUpvoteInput;
   CreatePostUpvotePayload: ResolverTypeWrapper<
-    ResolversUnionTypes<ResolversTypes>["CreatePostUpvotePayload"]
+    Omit<CreatePostUpvotePayload, "error"> & { error: Maybe<ResolversTypes["PostUpvoteError"]> }
   >;
   Date: ResolverTypeWrapper<Scalars["Date"]["output"]>;
   DateTime: ResolverTypeWrapper<Scalars["DateTime"]["output"]>;
@@ -504,24 +520,27 @@ export type ResolversTypes = ResolversObject<{
   PanoComment: ResolverTypeWrapper<PanoComment>;
   PanoCommentConnection: ResolverTypeWrapper<PanoCommentConnection>;
   PanoCommentEdge: ResolverTypeWrapper<PanoCommentEdge>;
+  PanoCommentError: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>["PanoCommentError"]>;
   PanoPost: ResolverTypeWrapper<PanoPost>;
   PanoPostConnection: ResolverTypeWrapper<PanoPostConnection>;
   PanoPostEdge: ResolverTypeWrapper<PanoPostEdge>;
+  PanoPostError: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>["PanoPostError"]>;
   PanoPostFilter: PanoPostFilter;
   PanoQuery: ResolverTypeWrapper<PanoQuery>;
   PostUpvote: ResolverTypeWrapper<PostUpvote>;
+  PostUpvoteError: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>["PostUpvoteError"]>;
   Query: ResolverTypeWrapper<{}>;
   RemovePanoCommentInput: RemovePanoCommentInput;
   RemovePanoCommentPayload: ResolverTypeWrapper<
-    ResolversUnionTypes<ResolversTypes>["RemovePanoCommentPayload"]
+    Omit<RemovePanoCommentPayload, "error"> & { error: Maybe<ResolversTypes["PanoCommentError"]> }
   >;
   RemovePanoPostInput: RemovePanoPostInput;
   RemovePanoPostPayload: ResolverTypeWrapper<
-    ResolversUnionTypes<ResolversTypes>["RemovePanoPostPayload"]
+    Omit<RemovePanoPostPayload, "error"> & { error: Maybe<ResolversTypes["PanoPostError"]> }
   >;
   RemovePostUpvoteInput: RemovePostUpvoteInput;
   RemovePostUpvotePayload: ResolverTypeWrapper<
-    ResolversUnionTypes<ResolversTypes>["RemovePostUpvotePayload"]
+    Omit<RemovePostUpvotePayload, "error"> & { error: Maybe<ResolversTypes["PostUpvoteError"]> }
   >;
   SozlukQuery: ResolverTypeWrapper<SozlukQuery>;
   SozlukTerm: ResolverTypeWrapper<SozlukTerm>;
@@ -531,11 +550,11 @@ export type ResolversTypes = ResolversObject<{
   String: ResolverTypeWrapper<Scalars["String"]["output"]>;
   UpdatePanoCommentInput: UpdatePanoCommentInput;
   UpdatePanoCommentPayload: ResolverTypeWrapper<
-    ResolversUnionTypes<ResolversTypes>["UpdatePanoCommentPayload"]
+    Omit<UpdatePanoCommentPayload, "error"> & { error: Maybe<ResolversTypes["PanoCommentError"]> }
   >;
   UpdatePanoPostInput: UpdatePanoPostInput;
   UpdatePanoPostPayload: ResolverTypeWrapper<
-    ResolversUnionTypes<ResolversTypes>["UpdatePanoPostPayload"]
+    Omit<UpdatePanoPostPayload, "error"> & { error: Maybe<ResolversTypes["PanoPostError"]> }
   >;
   User: ResolverTypeWrapper<User>;
   UserError: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>["UserError"]>;
@@ -547,11 +566,17 @@ export type ResolversParentTypes = ResolversObject<{
   Actor: ResolversInterfaceTypes<ResolversParentTypes>["Actor"];
   Boolean: Scalars["Boolean"]["output"];
   CreatePanoCommentInput: CreatePanoCommentInput;
-  CreatePanoCommentPayload: ResolversUnionTypes<ResolversParentTypes>["CreatePanoCommentPayload"];
+  CreatePanoCommentPayload: Omit<CreatePanoCommentPayload, "error"> & {
+    error: Maybe<ResolversParentTypes["PanoCommentError"]>;
+  };
   CreatePanoPostInput: CreatePanoPostInput;
-  CreatePanoPostPayload: ResolversUnionTypes<ResolversParentTypes>["CreatePanoPostPayload"];
+  CreatePanoPostPayload: Omit<CreatePanoPostPayload, "error"> & {
+    error: Maybe<ResolversParentTypes["PanoPostError"]>;
+  };
   CreatePostUpvoteInput: CreatePostUpvoteInput;
-  CreatePostUpvotePayload: ResolversUnionTypes<ResolversParentTypes>["CreatePostUpvotePayload"];
+  CreatePostUpvotePayload: Omit<CreatePostUpvotePayload, "error"> & {
+    error: Maybe<ResolversParentTypes["PostUpvoteError"]>;
+  };
   Date: Scalars["Date"]["output"];
   DateTime: Scalars["DateTime"]["output"];
   ID: Scalars["ID"]["output"];
@@ -564,18 +589,27 @@ export type ResolversParentTypes = ResolversObject<{
   PanoComment: PanoComment;
   PanoCommentConnection: PanoCommentConnection;
   PanoCommentEdge: PanoCommentEdge;
+  PanoCommentError: ResolversUnionTypes<ResolversParentTypes>["PanoCommentError"];
   PanoPost: PanoPost;
   PanoPostConnection: PanoPostConnection;
   PanoPostEdge: PanoPostEdge;
+  PanoPostError: ResolversUnionTypes<ResolversParentTypes>["PanoPostError"];
   PanoQuery: PanoQuery;
   PostUpvote: PostUpvote;
+  PostUpvoteError: ResolversUnionTypes<ResolversParentTypes>["PostUpvoteError"];
   Query: {};
   RemovePanoCommentInput: RemovePanoCommentInput;
-  RemovePanoCommentPayload: ResolversUnionTypes<ResolversParentTypes>["RemovePanoCommentPayload"];
+  RemovePanoCommentPayload: Omit<RemovePanoCommentPayload, "error"> & {
+    error: Maybe<ResolversParentTypes["PanoCommentError"]>;
+  };
   RemovePanoPostInput: RemovePanoPostInput;
-  RemovePanoPostPayload: ResolversUnionTypes<ResolversParentTypes>["RemovePanoPostPayload"];
+  RemovePanoPostPayload: Omit<RemovePanoPostPayload, "error"> & {
+    error: Maybe<ResolversParentTypes["PanoPostError"]>;
+  };
   RemovePostUpvoteInput: RemovePostUpvoteInput;
-  RemovePostUpvotePayload: ResolversUnionTypes<ResolversParentTypes>["RemovePostUpvotePayload"];
+  RemovePostUpvotePayload: Omit<RemovePostUpvotePayload, "error"> & {
+    error: Maybe<ResolversParentTypes["PostUpvoteError"]>;
+  };
   SozlukQuery: SozlukQuery;
   SozlukTerm: SozlukTerm;
   SozlukTermBody: SozlukTermBody;
@@ -583,9 +617,13 @@ export type ResolversParentTypes = ResolversObject<{
   SozlukTermEdge: SozlukTermEdge;
   String: Scalars["String"]["output"];
   UpdatePanoCommentInput: UpdatePanoCommentInput;
-  UpdatePanoCommentPayload: ResolversUnionTypes<ResolversParentTypes>["UpdatePanoCommentPayload"];
+  UpdatePanoCommentPayload: Omit<UpdatePanoCommentPayload, "error"> & {
+    error: Maybe<ResolversParentTypes["PanoCommentError"]>;
+  };
   UpdatePanoPostInput: UpdatePanoPostInput;
-  UpdatePanoPostPayload: ResolversUnionTypes<ResolversParentTypes>["UpdatePanoPostPayload"];
+  UpdatePanoPostPayload: Omit<UpdatePanoPostPayload, "error"> & {
+    error: Maybe<ResolversParentTypes["PanoPostError"]>;
+  };
   User: User;
   UserError: ResolversInterfaceTypes<ResolversParentTypes>["UserError"];
   Viewer: Viewer;
@@ -602,33 +640,27 @@ export type CreatePanoCommentPayloadResolvers<
   ContextType = KampusGQLContext,
   ParentType extends ResolversParentTypes["CreatePanoCommentPayload"] = ResolversParentTypes["CreatePanoCommentPayload"]
 > = ResolversObject<{
-  __resolveType?: TypeResolveFn<
-    "InvalidInput" | "NotAuthorized" | "PanoComment",
-    ParentType,
-    ContextType
-  >;
+  edge: Resolver<Maybe<ResolversTypes["PanoCommentEdge"]>, ParentType, ContextType>;
+  error: Resolver<Maybe<ResolversTypes["PanoCommentError"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type CreatePanoPostPayloadResolvers<
   ContextType = KampusGQLContext,
   ParentType extends ResolversParentTypes["CreatePanoPostPayload"] = ResolversParentTypes["CreatePanoPostPayload"]
 > = ResolversObject<{
-  __resolveType?: TypeResolveFn<
-    "InvalidInput" | "NotAuthorized" | "PanoPost",
-    ParentType,
-    ContextType
-  >;
+  edge: Resolver<Maybe<ResolversTypes["PanoPostEdge"]>, ParentType, ContextType>;
+  error: Resolver<Maybe<ResolversTypes["PanoPostError"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type CreatePostUpvotePayloadResolvers<
   ContextType = KampusGQLContext,
   ParentType extends ResolversParentTypes["CreatePostUpvotePayload"] = ResolversParentTypes["CreatePostUpvotePayload"]
 > = ResolversObject<{
-  __resolveType?: TypeResolveFn<
-    "InvalidInput" | "NotAuthorized" | "PostUpvote",
-    ParentType,
-    ContextType
-  >;
+  error: Resolver<Maybe<ResolversTypes["PostUpvoteError"]>, ParentType, ContextType>;
+  node: Resolver<Maybe<ResolversTypes["PostUpvote"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export interface DateScalarConfig extends GraphQLScalarTypeConfig<ResolversTypes["Date"], any> {
@@ -773,6 +805,13 @@ export type PanoCommentEdgeResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type PanoCommentErrorResolvers<
+  ContextType = KampusGQLContext,
+  ParentType extends ResolversParentTypes["PanoCommentError"] = ResolversParentTypes["PanoCommentError"]
+> = ResolversObject<{
+  __resolveType?: TypeResolveFn<"InvalidInput" | "NotAuthorized", ParentType, ContextType>;
+}>;
+
 export type PanoPostResolvers<
   ContextType = KampusGQLContext,
   ParentType extends ResolversParentTypes["PanoPost"] = ResolversParentTypes["PanoPost"]
@@ -815,6 +854,13 @@ export type PanoPostEdgeResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type PanoPostErrorResolvers<
+  ContextType = KampusGQLContext,
+  ParentType extends ResolversParentTypes["PanoPostError"] = ResolversParentTypes["PanoPostError"]
+> = ResolversObject<{
+  __resolveType?: TypeResolveFn<"InvalidInput" | "NotAuthorized", ParentType, ContextType>;
+}>;
+
 export type PanoQueryResolvers<
   ContextType = KampusGQLContext,
   ParentType extends ResolversParentTypes["PanoQuery"] = ResolversParentTypes["PanoQuery"]
@@ -844,6 +890,13 @@ export type PostUpvoteResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type PostUpvoteErrorResolvers<
+  ContextType = KampusGQLContext,
+  ParentType extends ResolversParentTypes["PostUpvoteError"] = ResolversParentTypes["PostUpvoteError"]
+> = ResolversObject<{
+  __resolveType?: TypeResolveFn<"InvalidInput" | "NotAuthorized", ParentType, ContextType>;
+}>;
+
 export type QueryResolvers<
   ContextType = KampusGQLContext,
   ParentType extends ResolversParentTypes["Query"] = ResolversParentTypes["Query"]
@@ -864,33 +917,27 @@ export type RemovePanoCommentPayloadResolvers<
   ContextType = KampusGQLContext,
   ParentType extends ResolversParentTypes["RemovePanoCommentPayload"] = ResolversParentTypes["RemovePanoCommentPayload"]
 > = ResolversObject<{
-  __resolveType?: TypeResolveFn<
-    "InvalidInput" | "NotAuthorized" | "PanoComment",
-    ParentType,
-    ContextType
-  >;
+  edge: Resolver<Maybe<ResolversTypes["PanoCommentEdge"]>, ParentType, ContextType>;
+  error: Resolver<Maybe<ResolversTypes["PanoCommentError"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type RemovePanoPostPayloadResolvers<
   ContextType = KampusGQLContext,
   ParentType extends ResolversParentTypes["RemovePanoPostPayload"] = ResolversParentTypes["RemovePanoPostPayload"]
 > = ResolversObject<{
-  __resolveType?: TypeResolveFn<
-    "InvalidInput" | "NotAuthorized" | "PanoPost",
-    ParentType,
-    ContextType
-  >;
+  edge: Resolver<Maybe<ResolversTypes["PanoPostEdge"]>, ParentType, ContextType>;
+  error: Resolver<Maybe<ResolversTypes["PanoPostError"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type RemovePostUpvotePayloadResolvers<
   ContextType = KampusGQLContext,
   ParentType extends ResolversParentTypes["RemovePostUpvotePayload"] = ResolversParentTypes["RemovePostUpvotePayload"]
 > = ResolversObject<{
-  __resolveType?: TypeResolveFn<
-    "InvalidInput" | "NotAuthorized" | "PostUpvote",
-    ParentType,
-    ContextType
-  >;
+  error: Resolver<Maybe<ResolversTypes["PostUpvoteError"]>, ParentType, ContextType>;
+  node: Resolver<Maybe<ResolversTypes["PostUpvote"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type SozlukQueryResolvers<
@@ -956,22 +1003,18 @@ export type UpdatePanoCommentPayloadResolvers<
   ContextType = KampusGQLContext,
   ParentType extends ResolversParentTypes["UpdatePanoCommentPayload"] = ResolversParentTypes["UpdatePanoCommentPayload"]
 > = ResolversObject<{
-  __resolveType?: TypeResolveFn<
-    "InvalidInput" | "NotAuthorized" | "PanoComment",
-    ParentType,
-    ContextType
-  >;
+  edge: Resolver<Maybe<ResolversTypes["PanoCommentEdge"]>, ParentType, ContextType>;
+  error: Resolver<Maybe<ResolversTypes["PanoCommentError"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type UpdatePanoPostPayloadResolvers<
   ContextType = KampusGQLContext,
   ParentType extends ResolversParentTypes["UpdatePanoPostPayload"] = ResolversParentTypes["UpdatePanoPostPayload"]
 > = ResolversObject<{
-  __resolveType?: TypeResolveFn<
-    "InvalidInput" | "NotAuthorized" | "PanoPost",
-    ParentType,
-    ContextType
-  >;
+  edge: Resolver<Maybe<ResolversTypes["PanoPostEdge"]>, ParentType, ContextType>;
+  error: Resolver<Maybe<ResolversTypes["PanoPostError"]>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type UserResolvers<
@@ -1026,11 +1069,14 @@ export type Resolvers<ContextType = KampusGQLContext> = ResolversObject<{
   PanoComment: PanoCommentResolvers<ContextType>;
   PanoCommentConnection: PanoCommentConnectionResolvers<ContextType>;
   PanoCommentEdge: PanoCommentEdgeResolvers<ContextType>;
+  PanoCommentError: PanoCommentErrorResolvers<ContextType>;
   PanoPost: PanoPostResolvers<ContextType>;
   PanoPostConnection: PanoPostConnectionResolvers<ContextType>;
   PanoPostEdge: PanoPostEdgeResolvers<ContextType>;
+  PanoPostError: PanoPostErrorResolvers<ContextType>;
   PanoQuery: PanoQueryResolvers<ContextType>;
   PostUpvote: PostUpvoteResolvers<ContextType>;
+  PostUpvoteError: PostUpvoteErrorResolvers<ContextType>;
   Query: QueryResolvers<ContextType>;
   RemovePanoCommentPayload: RemovePanoCommentPayloadResolvers<ContextType>;
   RemovePanoPostPayload: RemovePanoPostPayloadResolvers<ContextType>;


### PR DESCRIPTION
This is changing the payload types to be more predictable:

before:
```graphql
union CreatePanoPostPayload = PanoPost | NotAuthorized | InvalidInput
```
after:
```graphql
type CreatePanoPostPayload {
  edge: PanoPostEdge
  error: CreatePanoPostError
}

union CreatePanoPostError = NotAuthorized | InvalidInput
```

The reason is that relay wants us to return an edge typed object to be able to update related connections (eg. When a post is added, update the pano feed on pano home page)

https://relay.dev/docs/next/guided-tour/list-data/updating-connections