### PR TITLE
feat(gql/pano): show pano home page feed in descending order by `createdAt`

### DIFF
--- a/apps/gql/schema/resolvers/index.ts
+++ b/apps/gql/schema/resolvers/index.ts
@@ -98,7 +98,7 @@ export const resolvers = {
     },
     panoFeed: async (_, args, { loaders }) => {
       const posts = await loaders.pano.post.all.load(
-        new ConnectionKey(null, parseConnectionArgs(args))
+        new ConnectionKey(null, parseConnectionArgs(args), { orderBy: { createdAt: "desc" } })
       );
 
       return transformPanoPostConnection(posts);

--- a/packages/gql-utils/prisma/__mocks__/prisma.ts
+++ b/packages/gql-utils/prisma/__mocks__/prisma.ts
@@ -1,7 +1,7 @@
 import { beforeEach } from "vitest";
 import { mockDeep, mockReset } from "vitest-mock-extended";
 
-import { type PrismaClient, type Upvote, type User } from "@kampus/prisma";
+import { type Post, type PrismaClient, type Upvote, type User } from "@kampus/prisma";
 
 beforeEach(() => {
   mockReset(mockedPrisma);
@@ -11,7 +11,7 @@ export const mockedPrisma = mockDeep<PrismaClient>();
 
 export const mockDate = (overrides: string | number | Date = "2020/15/10") => new Date(overrides);
 
-export const mockUser = (overrides: Partial<User>): User => ({
+export const mockUser = (overrides: Partial<User> = {}): User => ({
   id: "1",
   username: "test",
   name: "test",
@@ -24,10 +24,23 @@ export const mockUser = (overrides: Partial<User>): User => ({
   ...overrides,
 });
 
-export const mockUpvote = (overrides: Partial<Upvote>): Upvote => ({
+export const mockUpvote = (overrides: Partial<Upvote> = {}): Upvote => ({
   id: "1",
   postID: "1",
   userID: "1",
+  createdAt: mockDate(),
+  updatedAt: mockDate(),
+  deletedAt: null,
+  ...overrides,
+});
+
+export const mockPost = (overrides: Partial<Post> = {}, owner = mockUser()): Post => ({
+  id: "1",
+  userID: owner.id,
+  title: "mock title",
+  content: "mock content",
+  url: null,
+  site: null,
   createdAt: mockDate(),
   updatedAt: mockDate(),
   deletedAt: null,

--- a/packages/gql-utils/prisma/connection-key.test.ts
+++ b/packages/gql-utils/prisma/connection-key.test.ts
@@ -6,12 +6,14 @@ describe(ConnectionKey, () => {
   it("works with when no parent", () => {
     const key = new ConnectionKey();
 
-    expect(key.args).toEqual({
+    expect(key.arguments()).toEqual({
       before: null,
       after: null,
       first: null,
       last: null,
     });
+
+    expect(key.getOverrides()).toEqual({});
   });
 
   describe("hash", () => {
@@ -27,6 +29,13 @@ describe(ConnectionKey, () => {
       [new ConnectionKey(null, { after: null, first: null })],
     ])("key: %j", (key) => {
       expect(key.hash()).toEqual(new ConnectionKey().hash());
+    });
+  });
+
+  describe("getOverrides", () => {
+    it("returns overrides", () => {
+      const key = new ConnectionKey(null, null, { orderBy: { createdAt: "desc" } });
+      expect(key.getOverrides()).toEqual({ orderBy: { createdAt: "desc" } });
     });
   });
 });

--- a/packages/gql-utils/prisma/create-connection-loader.test.ts
+++ b/packages/gql-utils/prisma/create-connection-loader.test.ts
@@ -1,58 +1,51 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { mockedPrisma, mockUser } from "./__mocks__/prisma";
+import { mockedPrisma, mockPost, mockUser } from "./__mocks__/prisma";
 import { ConnectionKey } from "./connection-key";
 import { createPrismaConnectionLoader } from "./create-connection-loader";
 
 describe(createPrismaConnectionLoader, () => {
   beforeEach(() => {
-    mockedPrisma.user.findMany.mockResolvedValueOnce([
-      mockUser({ id: "1" }),
-      mockUser({ id: "2" }),
-      mockUser({ id: "3" }),
-      mockUser({ id: "4" }),
-      mockUser({ id: "5" }),
-      mockUser({ id: "6" }),
+    mockedPrisma.post.findMany.mockResolvedValueOnce([
+      mockPost({ id: "1" }, mockUser({ id: "1" })),
+      mockPost({ id: "2" }, mockUser({ id: "2" })),
+      mockPost({ id: "3" }, mockUser({ id: "3" })),
+      mockPost({ id: "4" }, mockUser({ id: "4" })),
+      mockPost({ id: "5" }, mockUser({ id: "5" })),
+      mockPost({ id: "6" }, mockUser({ id: "6" })),
     ]);
   });
 
   it("works without a foreign key", async () => {
-    const allUsers = createPrismaConnectionLoader(mockedPrisma.user, null);
+    const allUsers = createPrismaConnectionLoader(mockedPrisma.post, null);
 
     await allUsers.load(new ConnectionKey());
 
-    expect(mockedPrisma.user.findMany.mock.lastCall?.[0]?.where).toEqual({
+    expect(mockedPrisma.post.findMany.mock.lastCall?.[0]?.where).toEqual({
       deletedAt: null,
     });
   });
 
   it("returns null when there is an identifier but no parentID in key", () => {
-    // need to find a better example because "name" doesn't make sense with "parentID"
-    // "name" needs to be replaced with an "id" column to represent real usecases.
-    const allUsers = createPrismaConnectionLoader(mockedPrisma.user, "name");
+    const postsByUserID = createPrismaConnectionLoader(mockedPrisma.post, "userID");
 
     void expect(async () => {
-      await allUsers.load(new ConnectionKey());
-    }).rejects.toThrowError(/name/);
+      await postsByUserID.load(new ConnectionKey());
+    }).rejects.toThrowError(/userID/);
   });
 
   it("works", async () => {
-    // need to find a better example because "name" doesn't make sense with "parentID"
-    // "name" needs to be replaced with an "id" column to represent real usecases.
-    const allUsers = createPrismaConnectionLoader(mockedPrisma.user, "name");
+    const postsByUserID = createPrismaConnectionLoader(mockedPrisma.post, "userID");
+    const users = await postsByUserID.load(new ConnectionKey("umut"));
 
-    const users = await allUsers.load(new ConnectionKey("umut"));
     expect(users).not.toBeNull();
   });
 
   it("accepts a completion handler", async () => {
     const onComplete = vi.fn();
+    const postsByUserID = createPrismaConnectionLoader(mockedPrisma.post, "userID", onComplete);
 
-    // need to find a better example because "name" doesn't make sense with "parentID"
-    // "name" needs to be replaced with an "id" column to represent real usecases.
-    const allUsers = createPrismaConnectionLoader(mockedPrisma.user, "name", onComplete);
-
-    const users = await allUsers.load(new ConnectionKey("umut"));
+    const users = await postsByUserID.load(new ConnectionKey("umut"));
 
     expect(onComplete).toHaveBeenCalledWith([users]);
   });

--- a/packages/gql-utils/prisma/create-connection-loader.ts
+++ b/packages/gql-utils/prisma/create-connection-loader.ts
@@ -7,7 +7,7 @@ import { type PrismaModel } from "./types";
 
 export function createPrismaConnectionLoader<TPrisma extends { id: string }>(
   table: PrismaModel<TPrisma>,
-  identifier: string | null,
+  identifier: keyof TPrisma | null,
   onFetchComplete?: (connection: Connection<TPrisma>[]) => void
 ) {
   return new DataLoader(
@@ -15,7 +15,7 @@ export function createPrismaConnectionLoader<TPrisma extends { id: string }>(
       const items = await Promise.all(
         keys.map(async (key) => {
           if (identifier && !key.parentID) {
-            return new Error(`"${identifier}" is required`);
+            return new Error(`"${identifier as string}" is required`);
           }
 
           const where =

--- a/packages/gql-utils/prisma/create-connection-loader.ts
+++ b/packages/gql-utils/prisma/create-connection-loader.ts
@@ -23,9 +23,11 @@ export function createPrismaConnectionLoader<TPrisma extends { id: string }>(
               ? { [identifier]: key.parentID, deletedAt: null }
               : { deletedAt: null };
 
+          const queryArgs = { where, ...key.getOverrides() };
+
           return findManyCursorConnection(
-            (args) => table.findMany({ ...args, where }),
-            () => table.count({ where }),
+            (args) => table.findMany({ ...args, ...queryArgs }),
+            () => table.count({ where: queryArgs.where }),
             key.arguments()
           );
         })

--- a/packages/gql-utils/prisma/create-count-loader.ts
+++ b/packages/gql-utils/prisma/create-count-loader.ts
@@ -5,7 +5,7 @@ import { type PrismaModel } from "./types";
 
 export function createPrismaCountLoader<TPrisma extends { id: string }>(
   table: PrismaModel<TPrisma>,
-  identifier: string
+  identifier: keyof TPrisma
 ) {
   return new DataLoader(async (keys: readonly ConnectionKey[]) => {
     const counts = await Promise.all(

--- a/packages/gql-utils/prisma/create-loader.ts
+++ b/packages/gql-utils/prisma/create-loader.ts
@@ -37,7 +37,7 @@ import { type PrismaModel } from "./types";
  */
 export function createPrismaLoader<TModel extends Record<string, unknown>>(
   model: PrismaModel<TModel>,
-  identifier: string,
+  identifier: keyof TModel,
   onFetchComplete?: (items: TModel[]) => void
 ) {
   return new DataLoader<string, TModel>(async (keys: readonly string[]) => {
@@ -53,7 +53,7 @@ export function createPrismaLoader<TModel extends Record<string, unknown>>(
     return keys.map((key) => {
       return (
         items.find((item) => item[identifier] === key) ??
-        new Error(`not found: ${identifier}: ${key}`)
+        new Error(`not found: ${identifier as string}: ${key}`)
       );
     });
   });


### PR DESCRIPTION
Add support for connection loaders to extend base arguments we pass to `prisma.model.findMany`

- [x] Closes #617 