### PR TITLE
feat(apps/gql): handle upvote mutations better & add `PanoPost.isUpvotedByViewer` resolver

### DIFF
--- a/apps/gql/loaders/pano.ts
+++ b/apps/gql/loaders/pano.ts
@@ -67,13 +67,14 @@ const createPanoUpvoteLoaders = ({ prisma }: Clients) => {
         results.map((result) => (result.status === "fulfilled" ? result.value : null))
       );
 
-      results.forEach((upvote) => {
+      return results;
+    },
+    (results) => {
+      results?.forEach((upvote) => {
         if (upvote) {
           byPostID.prime(upvote.id, upvote);
         }
       });
-
-      return results;
     }
   );
 
@@ -87,13 +88,14 @@ const createPanoUpvoteLoaders = ({ prisma }: Clients) => {
         results.map((result) => (result.status === "fulfilled" ? result.value : null))
       );
 
-      results.forEach((upvote) => {
+      return results;
+    },
+    (results) => {
+      results?.forEach((upvote) => {
         if (upvote) {
           byCommentID.prime(upvote.id, upvote);
         }
       });
-
-      return results;
     }
   );
 

--- a/apps/gql/loaders/pano.ts
+++ b/apps/gql/loaders/pano.ts
@@ -67,9 +67,22 @@ const createPanoUpvoteLoaders = ({ prisma }: Clients) => {
     }
   );
 
+  const byUserAndCommentID = createDataLoader(
+    async (keys: readonly { commentID: string; userID: string }[]) => {
+      const promises = keys.map(({ commentID, userID }) =>
+        prisma.commentUpvote.findUnique({ where: { commentID_userID: { commentID, userID } } })
+      );
+
+      return Promise.allSettled(promises).then((results) =>
+        results.map((result) => (result.status === "fulfilled" ? result.value : null))
+      );
+    }
+  );
+
   return {
     byID,
     byUserAndPostID,
+    byUserAndCommentID,
     countByPostID,
     countByCommentID,
   };
@@ -146,6 +159,7 @@ export const transformPanoComment = (comment: Comment) => {
     comments: null,
     commentCount: null,
     upvoteCount: null,
+    isUpvotedByViewer: false,
     createdAt: comment.createdAt.toISOString(),
   } satisfies PanoComment;
 };

--- a/apps/gql/schema/resolvers/index.ts
+++ b/apps/gql/schema/resolvers/index.ts
@@ -246,6 +246,18 @@ export const resolvers = {
     upvoteCount: (comment, _, { loaders }) => {
       return loaders.pano.upvote.countByCommentID.load(new ConnectionKey(comment.id));
     },
+    isUpvotedByViewer: async (comment, _, { loaders, pasaport: { session } }) => {
+      if (!session?.user?.id) {
+        return false;
+      }
+
+      const upvote = await loaders.pano.upvote.byUserAndCommentID.load({
+        userID: session?.user.id,
+        commentID: comment.id,
+      });
+
+      return !!upvote;
+    },
     createdAt: (comment) => comment.createdAt,
   },
   PanoCommentEdge: {
@@ -377,7 +389,7 @@ export const resolvers = {
       }
 
       const node = await actions.pano.comment
-        .create({ ...input, userID: session.user.id })
+        .create({ ...input, postID: parse(input.postID).value, userID: session.user.id })
         .then((created) => loaders.pano.comment.byID.load(created.id))
         .then(transformPanoComment);
 

--- a/apps/gql/schema/resolvers/index.ts
+++ b/apps/gql/schema/resolvers/index.ts
@@ -86,7 +86,6 @@ export const resolvers = {
   },
   Viewer: {
     actor: async (_viewer, _args, { loaders, pasaport: { session } }) => {
-      console.log(1, { session });
       if (!session?.user?.id) {
         return null;
       }

--- a/apps/gql/schema/schema.graphql
+++ b/apps/gql/schema/schema.graphql
@@ -145,6 +145,7 @@ type PanoComment implements Node {
   comments(after: String, before: String, first: Int, last: Int): PanoCommentConnection
   commentCount: Int
   upvoteCount: Int
+  isUpvotedByViewer: Boolean!
   createdAt: DateTime!
 }
 

--- a/apps/gql/schema/schema.graphql
+++ b/apps/gql/schema/schema.graphql
@@ -121,6 +121,7 @@ type PanoPost implements Node {
   comments(after: String, before: String, first: Int, last: Int): PanoCommentConnection
   commentCount: Int
   upvoteCount: Int
+  isUpvotedByViewer: Boolean!
 }
 
 type PanoPostConnection {

--- a/apps/gql/schema/schema.graphql
+++ b/apps/gql/schema/schema.graphql
@@ -14,6 +14,10 @@ interface UserError {
   message: String!
 }
 
+interface Upvotable {
+  isUpvotedByViewer: Boolean!
+}
+
 type Query {
   # we need to have a way to encode the typename into id
   # so that `Query.node` can decode it and figure out what to resolve
@@ -110,7 +114,7 @@ enum PanoPostFilter {
   SELF
 }
 
-type PanoPost implements Node {
+type PanoPost implements Node & Upvotable {
   id: ID!
   title: String!
   url: String
@@ -161,12 +165,6 @@ type PanoCommentEdge {
   node: PanoComment
 }
 
-type PostUpvote {
-  id: ID!
-  post: PanoPost
-  owner: User
-}
-
 type Mutation {
   createPanoPost(input: CreatePanoPostInput!): CreatePanoPostPayload
   updatePanoPost(input: UpdatePanoPostInput!): UpdatePanoPostPayload
@@ -176,8 +174,8 @@ type Mutation {
   updatePanoComment(input: UpdatePanoCommentInput!): UpdatePanoCommentPayload
   removePanoComment(input: RemovePanoCommentInput!): RemovePanoCommentPayload
 
-  createPostUpvote(input: CreatePostUpvoteInput!): CreatePostUpvotePayload
-  removePostUpvote(input: RemovePostUpvoteInput!): RemovePostUpvotePayload
+  createPanoUpvote(input: CreatePanoUpvoteInput!): CreatePanoUpvotePayload
+  removePanoUpvote(input: RemovePanoUpvoteInput!): RemovePanoUpvotePayload
 }
 
 # Pano post mutations
@@ -252,22 +250,28 @@ type RemovePanoCommentPayload {
 
 # Pano post upvote mutations
 
-union PostUpvoteError = NotAuthorized | InvalidInput
+union PanoUpvoteError = NotAuthorized | InvalidInput
 
-input CreatePostUpvoteInput {
-  postID: String!
+type PanoUpvote {
+  id: ID!
+  node: Upvotable
+  owner: User
 }
 
-type CreatePostUpvotePayload {
-  node: PostUpvote
-  error: PostUpvoteError
+input CreatePanoUpvoteInput {
+  id: ID!
 }
 
-input RemovePostUpvoteInput {
-  postID: String!
+type CreatePanoUpvotePayload {
+  node: PanoUpvote
+  error: PanoUpvoteError
 }
 
-type RemovePostUpvotePayload {
-  node: PostUpvote
-  error: PostUpvoteError
+input RemovePanoUpvoteInput {
+  id: ID!
+}
+
+type RemovePanoUpvotePayload {
+  node: PanoUpvote
+  error: PanoUpvoteError
 }

--- a/apps/gql/schema/types.generated.ts
+++ b/apps/gql/schema/types.generated.ts
@@ -138,6 +138,7 @@ export type PanoComment = Node & {
   content: Scalars["String"]["output"];
   createdAt: Scalars["DateTime"]["output"];
   id: Scalars["ID"]["output"];
+  isUpvotedByViewer: Scalars["Boolean"]["output"];
   owner: Maybe<User>;
   parent: Maybe<PanoComment>;
   post: Maybe<PanoPost>;
@@ -786,6 +787,7 @@ export type PanoCommentResolvers<
   content: Resolver<ResolversTypes["String"], ParentType, ContextType>;
   createdAt: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
   id: Resolver<ResolversTypes["ID"], ParentType, ContextType>;
+  isUpvotedByViewer: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
   owner: Resolver<Maybe<ResolversTypes["User"]>, ParentType, ContextType>;
   parent: Resolver<Maybe<ResolversTypes["PanoComment"]>, ParentType, ContextType>;
   post: Resolver<Maybe<ResolversTypes["PanoPost"]>, ParentType, ContextType>;

--- a/apps/gql/schema/types.generated.ts
+++ b/apps/gql/schema/types.generated.ts
@@ -174,6 +174,7 @@ export type PanoPost = Node & {
   content: Maybe<Scalars["String"]["output"]>;
   createdAt: Scalars["DateTime"]["output"];
   id: Scalars["ID"]["output"];
+  isUpvotedByViewer: Scalars["Boolean"]["output"];
   owner: Maybe<User>;
   site: Maybe<Scalars["String"]["output"]>;
   title: Scalars["String"]["output"];
@@ -833,6 +834,7 @@ export type PanoPostResolvers<
   content: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
   createdAt: Resolver<ResolversTypes["DateTime"], ParentType, ContextType>;
   id: Resolver<ResolversTypes["ID"], ParentType, ContextType>;
+  isUpvotedByViewer: Resolver<ResolversTypes["Boolean"], ParentType, ContextType>;
   owner: Resolver<Maybe<ResolversTypes["User"]>, ParentType, ContextType>;
   site: Resolver<Maybe<ResolversTypes["String"]>, ParentType, ContextType>;
   title: Resolver<ResolversTypes["String"], ParentType, ContextType>;

--- a/apps/gql/schema/types.generated.ts
+++ b/apps/gql/schema/types.generated.ts
@@ -55,14 +55,14 @@ export type CreatePanoPostPayload = {
   error: Maybe<PanoPostError>;
 };
 
-export type CreatePostUpvoteInput = {
-  postID: Scalars["String"]["input"];
+export type CreatePanoUpvoteInput = {
+  id: Scalars["ID"]["input"];
 };
 
-export type CreatePostUpvotePayload = {
-  __typename?: "CreatePostUpvotePayload";
-  error: Maybe<PostUpvoteError>;
-  node: Maybe<PostUpvote>;
+export type CreatePanoUpvotePayload = {
+  __typename?: "CreatePanoUpvotePayload";
+  error: Maybe<PanoUpvoteError>;
+  node: Maybe<PanoUpvote>;
 };
 
 export type InvalidInput = UserError & {
@@ -74,10 +74,10 @@ export type Mutation = {
   __typename?: "Mutation";
   createPanoComment: Maybe<CreatePanoCommentPayload>;
   createPanoPost: Maybe<CreatePanoPostPayload>;
-  createPostUpvote: Maybe<CreatePostUpvotePayload>;
+  createPanoUpvote: Maybe<CreatePanoUpvotePayload>;
   removePanoComment: Maybe<RemovePanoCommentPayload>;
   removePanoPost: Maybe<RemovePanoPostPayload>;
-  removePostUpvote: Maybe<RemovePostUpvotePayload>;
+  removePanoUpvote: Maybe<RemovePanoUpvotePayload>;
   updatePanoComment: Maybe<UpdatePanoCommentPayload>;
   updatePanoPost: Maybe<UpdatePanoPostPayload>;
 };
@@ -90,8 +90,8 @@ export type MutationCreatePanoPostArgs = {
   input: CreatePanoPostInput;
 };
 
-export type MutationCreatePostUpvoteArgs = {
-  input: CreatePostUpvoteInput;
+export type MutationCreatePanoUpvoteArgs = {
+  input: CreatePanoUpvoteInput;
 };
 
 export type MutationRemovePanoCommentArgs = {
@@ -102,8 +102,8 @@ export type MutationRemovePanoPostArgs = {
   input: RemovePanoPostInput;
 };
 
-export type MutationRemovePostUpvoteArgs = {
-  input: RemovePostUpvoteInput;
+export type MutationRemovePanoUpvoteArgs = {
+  input: RemovePanoUpvoteInput;
 };
 
 export type MutationUpdatePanoCommentArgs = {
@@ -168,20 +168,21 @@ export type PanoCommentEdge = {
 
 export type PanoCommentError = InvalidInput | NotAuthorized;
 
-export type PanoPost = Node & {
-  __typename?: "PanoPost";
-  commentCount: Maybe<Scalars["Int"]["output"]>;
-  comments: Maybe<PanoCommentConnection>;
-  content: Maybe<Scalars["String"]["output"]>;
-  createdAt: Scalars["DateTime"]["output"];
-  id: Scalars["ID"]["output"];
-  isUpvotedByViewer: Scalars["Boolean"]["output"];
-  owner: Maybe<User>;
-  site: Maybe<Scalars["String"]["output"]>;
-  title: Scalars["String"]["output"];
-  upvoteCount: Maybe<Scalars["Int"]["output"]>;
-  url: Maybe<Scalars["String"]["output"]>;
-};
+export type PanoPost = Node &
+  Upvotable & {
+    __typename?: "PanoPost";
+    commentCount: Maybe<Scalars["Int"]["output"]>;
+    comments: Maybe<PanoCommentConnection>;
+    content: Maybe<Scalars["String"]["output"]>;
+    createdAt: Scalars["DateTime"]["output"];
+    id: Scalars["ID"]["output"];
+    isUpvotedByViewer: Scalars["Boolean"]["output"];
+    owner: Maybe<User>;
+    site: Maybe<Scalars["String"]["output"]>;
+    title: Scalars["String"]["output"];
+    upvoteCount: Maybe<Scalars["Int"]["output"]>;
+    url: Maybe<Scalars["String"]["output"]>;
+  };
 
 export type PanoPostCommentsArgs = {
   after: InputMaybe<Scalars["String"]["input"]>;
@@ -229,14 +230,14 @@ export type PanoQueryPostsBySiteArgs = {
   site: Scalars["String"]["input"];
 };
 
-export type PostUpvote = {
-  __typename?: "PostUpvote";
+export type PanoUpvote = {
+  __typename?: "PanoUpvote";
   id: Scalars["ID"]["output"];
+  node: Maybe<Upvotable>;
   owner: Maybe<User>;
-  post: Maybe<PanoPost>;
 };
 
-export type PostUpvoteError = InvalidInput | NotAuthorized;
+export type PanoUpvoteError = InvalidInput | NotAuthorized;
 
 export type Query = {
   __typename?: "Query";
@@ -276,14 +277,14 @@ export type RemovePanoPostPayload = {
   error: Maybe<PanoPostError>;
 };
 
-export type RemovePostUpvoteInput = {
-  postID: Scalars["String"]["input"];
+export type RemovePanoUpvoteInput = {
+  id: Scalars["ID"]["input"];
 };
 
-export type RemovePostUpvotePayload = {
-  __typename?: "RemovePostUpvotePayload";
-  error: Maybe<PostUpvoteError>;
-  node: Maybe<PostUpvote>;
+export type RemovePanoUpvotePayload = {
+  __typename?: "RemovePanoUpvotePayload";
+  error: Maybe<PanoUpvoteError>;
+  node: Maybe<PanoUpvote>;
 };
 
 export type SozlukQuery = {
@@ -353,6 +354,10 @@ export type UpdatePanoPostPayload = {
   __typename?: "UpdatePanoPostPayload";
   edge: Maybe<PanoPostEdge>;
   error: Maybe<PanoPostError>;
+};
+
+export type Upvotable = {
+  isUpvotedByViewer: Scalars["Boolean"]["output"];
 };
 
 export type User = Actor &
@@ -483,7 +488,7 @@ export type ResolversUnionTypes<RefType extends Record<string, unknown>> = Resol
   PanoPostError:
     | (InvalidInput & { __typename: "InvalidInput" })
     | (NotAuthorized & { __typename: "NotAuthorized" });
-  PostUpvoteError:
+  PanoUpvoteError:
     | (InvalidInput & { __typename: "InvalidInput" })
     | (NotAuthorized & { __typename: "NotAuthorized" });
 }>;
@@ -496,6 +501,7 @@ export type ResolversInterfaceTypes<RefType extends Record<string, unknown>> = R
     | (PanoPost & { __typename: "PanoPost" })
     | (SozlukTerm & { __typename: "SozlukTerm" })
     | (User & { __typename: "User" });
+  Upvotable: PanoPost & { __typename: "PanoPost" };
   UserError:
     | (InvalidInput & { __typename: "InvalidInput" })
     | (NotAuthorized & { __typename: "NotAuthorized" });
@@ -513,9 +519,9 @@ export type ResolversTypes = ResolversObject<{
   CreatePanoPostPayload: ResolverTypeWrapper<
     Omit<CreatePanoPostPayload, "error"> & { error: Maybe<ResolversTypes["PanoPostError"]> }
   >;
-  CreatePostUpvoteInput: CreatePostUpvoteInput;
-  CreatePostUpvotePayload: ResolverTypeWrapper<
-    Omit<CreatePostUpvotePayload, "error"> & { error: Maybe<ResolversTypes["PostUpvoteError"]> }
+  CreatePanoUpvoteInput: CreatePanoUpvoteInput;
+  CreatePanoUpvotePayload: ResolverTypeWrapper<
+    Omit<CreatePanoUpvotePayload, "error"> & { error: Maybe<ResolversTypes["PanoUpvoteError"]> }
   >;
   Date: ResolverTypeWrapper<Scalars["Date"]["output"]>;
   DateTime: ResolverTypeWrapper<Scalars["DateTime"]["output"]>;
@@ -536,8 +542,8 @@ export type ResolversTypes = ResolversObject<{
   PanoPostError: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>["PanoPostError"]>;
   PanoPostFilter: PanoPostFilter;
   PanoQuery: ResolverTypeWrapper<PanoQuery>;
-  PostUpvote: ResolverTypeWrapper<PostUpvote>;
-  PostUpvoteError: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>["PostUpvoteError"]>;
+  PanoUpvote: ResolverTypeWrapper<PanoUpvote>;
+  PanoUpvoteError: ResolverTypeWrapper<ResolversUnionTypes<ResolversTypes>["PanoUpvoteError"]>;
   Query: ResolverTypeWrapper<{}>;
   RemovePanoCommentInput: RemovePanoCommentInput;
   RemovePanoCommentPayload: ResolverTypeWrapper<
@@ -547,9 +553,9 @@ export type ResolversTypes = ResolversObject<{
   RemovePanoPostPayload: ResolverTypeWrapper<
     Omit<RemovePanoPostPayload, "error"> & { error: Maybe<ResolversTypes["PanoPostError"]> }
   >;
-  RemovePostUpvoteInput: RemovePostUpvoteInput;
-  RemovePostUpvotePayload: ResolverTypeWrapper<
-    Omit<RemovePostUpvotePayload, "error"> & { error: Maybe<ResolversTypes["PostUpvoteError"]> }
+  RemovePanoUpvoteInput: RemovePanoUpvoteInput;
+  RemovePanoUpvotePayload: ResolverTypeWrapper<
+    Omit<RemovePanoUpvotePayload, "error"> & { error: Maybe<ResolversTypes["PanoUpvoteError"]> }
   >;
   SozlukQuery: ResolverTypeWrapper<SozlukQuery>;
   SozlukTerm: ResolverTypeWrapper<SozlukTerm>;
@@ -565,6 +571,7 @@ export type ResolversTypes = ResolversObject<{
   UpdatePanoPostPayload: ResolverTypeWrapper<
     Omit<UpdatePanoPostPayload, "error"> & { error: Maybe<ResolversTypes["PanoPostError"]> }
   >;
+  Upvotable: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>["Upvotable"]>;
   User: ResolverTypeWrapper<User>;
   UserError: ResolverTypeWrapper<ResolversInterfaceTypes<ResolversTypes>["UserError"]>;
   Viewer: ResolverTypeWrapper<Viewer>;
@@ -582,9 +589,9 @@ export type ResolversParentTypes = ResolversObject<{
   CreatePanoPostPayload: Omit<CreatePanoPostPayload, "error"> & {
     error: Maybe<ResolversParentTypes["PanoPostError"]>;
   };
-  CreatePostUpvoteInput: CreatePostUpvoteInput;
-  CreatePostUpvotePayload: Omit<CreatePostUpvotePayload, "error"> & {
-    error: Maybe<ResolversParentTypes["PostUpvoteError"]>;
+  CreatePanoUpvoteInput: CreatePanoUpvoteInput;
+  CreatePanoUpvotePayload: Omit<CreatePanoUpvotePayload, "error"> & {
+    error: Maybe<ResolversParentTypes["PanoUpvoteError"]>;
   };
   Date: Scalars["Date"]["output"];
   DateTime: Scalars["DateTime"]["output"];
@@ -604,8 +611,8 @@ export type ResolversParentTypes = ResolversObject<{
   PanoPostEdge: PanoPostEdge;
   PanoPostError: ResolversUnionTypes<ResolversParentTypes>["PanoPostError"];
   PanoQuery: PanoQuery;
-  PostUpvote: PostUpvote;
-  PostUpvoteError: ResolversUnionTypes<ResolversParentTypes>["PostUpvoteError"];
+  PanoUpvote: PanoUpvote;
+  PanoUpvoteError: ResolversUnionTypes<ResolversParentTypes>["PanoUpvoteError"];
   Query: {};
   RemovePanoCommentInput: RemovePanoCommentInput;
   RemovePanoCommentPayload: Omit<RemovePanoCommentPayload, "error"> & {
@@ -615,9 +622,9 @@ export type ResolversParentTypes = ResolversObject<{
   RemovePanoPostPayload: Omit<RemovePanoPostPayload, "error"> & {
     error: Maybe<ResolversParentTypes["PanoPostError"]>;
   };
-  RemovePostUpvoteInput: RemovePostUpvoteInput;
-  RemovePostUpvotePayload: Omit<RemovePostUpvotePayload, "error"> & {
-    error: Maybe<ResolversParentTypes["PostUpvoteError"]>;
+  RemovePanoUpvoteInput: RemovePanoUpvoteInput;
+  RemovePanoUpvotePayload: Omit<RemovePanoUpvotePayload, "error"> & {
+    error: Maybe<ResolversParentTypes["PanoUpvoteError"]>;
   };
   SozlukQuery: SozlukQuery;
   SozlukTerm: SozlukTerm;
@@ -633,6 +640,7 @@ export type ResolversParentTypes = ResolversObject<{
   UpdatePanoPostPayload: Omit<UpdatePanoPostPayload, "error"> & {
     error: Maybe<ResolversParentTypes["PanoPostError"]>;
   };
+  Upvotable: ResolversInterfaceTypes<ResolversParentTypes>["Upvotable"];
   User: User;
   UserError: ResolversInterfaceTypes<ResolversParentTypes>["UserError"];
   Viewer: Viewer;
@@ -663,12 +671,12 @@ export type CreatePanoPostPayloadResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
-export type CreatePostUpvotePayloadResolvers<
+export type CreatePanoUpvotePayloadResolvers<
   ContextType = KampusGQLContext,
-  ParentType extends ResolversParentTypes["CreatePostUpvotePayload"] = ResolversParentTypes["CreatePostUpvotePayload"]
+  ParentType extends ResolversParentTypes["CreatePanoUpvotePayload"] = ResolversParentTypes["CreatePanoUpvotePayload"]
 > = ResolversObject<{
-  error: Resolver<Maybe<ResolversTypes["PostUpvoteError"]>, ParentType, ContextType>;
-  node: Resolver<Maybe<ResolversTypes["PostUpvote"]>, ParentType, ContextType>;
+  error: Resolver<Maybe<ResolversTypes["PanoUpvoteError"]>, ParentType, ContextType>;
+  node: Resolver<Maybe<ResolversTypes["PanoUpvote"]>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -705,11 +713,11 @@ export type MutationResolvers<
     ContextType,
     RequireFields<MutationCreatePanoPostArgs, "input">
   >;
-  createPostUpvote: Resolver<
-    Maybe<ResolversTypes["CreatePostUpvotePayload"]>,
+  createPanoUpvote: Resolver<
+    Maybe<ResolversTypes["CreatePanoUpvotePayload"]>,
     ParentType,
     ContextType,
-    RequireFields<MutationCreatePostUpvoteArgs, "input">
+    RequireFields<MutationCreatePanoUpvoteArgs, "input">
   >;
   removePanoComment: Resolver<
     Maybe<ResolversTypes["RemovePanoCommentPayload"]>,
@@ -723,11 +731,11 @@ export type MutationResolvers<
     ContextType,
     RequireFields<MutationRemovePanoPostArgs, "input">
   >;
-  removePostUpvote: Resolver<
-    Maybe<ResolversTypes["RemovePostUpvotePayload"]>,
+  removePanoUpvote: Resolver<
+    Maybe<ResolversTypes["RemovePanoUpvotePayload"]>,
     ParentType,
     ContextType,
-    RequireFields<MutationRemovePostUpvoteArgs, "input">
+    RequireFields<MutationRemovePanoUpvoteArgs, "input">
   >;
   updatePanoComment: Resolver<
     Maybe<ResolversTypes["UpdatePanoCommentPayload"]>,
@@ -897,19 +905,19 @@ export type PanoQueryResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
-export type PostUpvoteResolvers<
+export type PanoUpvoteResolvers<
   ContextType = KampusGQLContext,
-  ParentType extends ResolversParentTypes["PostUpvote"] = ResolversParentTypes["PostUpvote"]
+  ParentType extends ResolversParentTypes["PanoUpvote"] = ResolversParentTypes["PanoUpvote"]
 > = ResolversObject<{
   id: Resolver<ResolversTypes["ID"], ParentType, ContextType>;
+  node: Resolver<Maybe<ResolversTypes["Upvotable"]>, ParentType, ContextType>;
   owner: Resolver<Maybe<ResolversTypes["User"]>, ParentType, ContextType>;
-  post: Resolver<Maybe<ResolversTypes["PanoPost"]>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
-export type PostUpvoteErrorResolvers<
+export type PanoUpvoteErrorResolvers<
   ContextType = KampusGQLContext,
-  ParentType extends ResolversParentTypes["PostUpvoteError"] = ResolversParentTypes["PostUpvoteError"]
+  ParentType extends ResolversParentTypes["PanoUpvoteError"] = ResolversParentTypes["PanoUpvoteError"]
 > = ResolversObject<{
   __resolveType?: TypeResolveFn<"InvalidInput" | "NotAuthorized", ParentType, ContextType>;
 }>;
@@ -948,12 +956,12 @@ export type RemovePanoPostPayloadResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
-export type RemovePostUpvotePayloadResolvers<
+export type RemovePanoUpvotePayloadResolvers<
   ContextType = KampusGQLContext,
-  ParentType extends ResolversParentTypes["RemovePostUpvotePayload"] = ResolversParentTypes["RemovePostUpvotePayload"]
+  ParentType extends ResolversParentTypes["RemovePanoUpvotePayload"] = ResolversParentTypes["RemovePanoUpvotePayload"]
 > = ResolversObject<{
-  error: Resolver<Maybe<ResolversTypes["PostUpvoteError"]>, ParentType, ContextType>;
-  node: Resolver<Maybe<ResolversTypes["PostUpvote"]>, ParentType, ContextType>;
+  error: Resolver<Maybe<ResolversTypes["PanoUpvoteError"]>, ParentType, ContextType>;
+  node: Resolver<Maybe<ResolversTypes["PanoUpvote"]>, ParentType, ContextType>;
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
@@ -1034,6 +1042,13 @@ export type UpdatePanoPostPayloadResolvers<
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type UpvotableResolvers<
+  ContextType = KampusGQLContext,
+  ParentType extends ResolversParentTypes["Upvotable"] = ResolversParentTypes["Upvotable"]
+> = ResolversObject<{
+  __resolveType?: TypeResolveFn<"PanoPost", ParentType, ContextType>;
+}>;
+
 export type UserResolvers<
   ContextType = KampusGQLContext,
   ParentType extends ResolversParentTypes["User"] = ResolversParentTypes["User"]
@@ -1075,7 +1090,7 @@ export type Resolvers<ContextType = KampusGQLContext> = ResolversObject<{
   Actor: ActorResolvers<ContextType>;
   CreatePanoCommentPayload: CreatePanoCommentPayloadResolvers<ContextType>;
   CreatePanoPostPayload: CreatePanoPostPayloadResolvers<ContextType>;
-  CreatePostUpvotePayload: CreatePostUpvotePayloadResolvers<ContextType>;
+  CreatePanoUpvotePayload: CreatePanoUpvotePayloadResolvers<ContextType>;
   Date: GraphQLScalarType;
   DateTime: GraphQLScalarType;
   InvalidInput: InvalidInputResolvers<ContextType>;
@@ -1092,12 +1107,12 @@ export type Resolvers<ContextType = KampusGQLContext> = ResolversObject<{
   PanoPostEdge: PanoPostEdgeResolvers<ContextType>;
   PanoPostError: PanoPostErrorResolvers<ContextType>;
   PanoQuery: PanoQueryResolvers<ContextType>;
-  PostUpvote: PostUpvoteResolvers<ContextType>;
-  PostUpvoteError: PostUpvoteErrorResolvers<ContextType>;
+  PanoUpvote: PanoUpvoteResolvers<ContextType>;
+  PanoUpvoteError: PanoUpvoteErrorResolvers<ContextType>;
   Query: QueryResolvers<ContextType>;
   RemovePanoCommentPayload: RemovePanoCommentPayloadResolvers<ContextType>;
   RemovePanoPostPayload: RemovePanoPostPayloadResolvers<ContextType>;
-  RemovePostUpvotePayload: RemovePostUpvotePayloadResolvers<ContextType>;
+  RemovePanoUpvotePayload: RemovePanoUpvotePayloadResolvers<ContextType>;
   SozlukQuery: SozlukQueryResolvers<ContextType>;
   SozlukTerm: SozlukTermResolvers<ContextType>;
   SozlukTermBody: SozlukTermBodyResolvers<ContextType>;
@@ -1105,6 +1120,7 @@ export type Resolvers<ContextType = KampusGQLContext> = ResolversObject<{
   SozlukTermEdge: SozlukTermEdgeResolvers<ContextType>;
   UpdatePanoCommentPayload: UpdatePanoCommentPayloadResolvers<ContextType>;
   UpdatePanoPostPayload: UpdatePanoPostPayloadResolvers<ContextType>;
+  Upvotable: UpvotableResolvers<ContextType>;
   User: UserResolvers<ContextType>;
   UserError: UserErrorResolvers<ContextType>;
   Viewer: ViewerResolvers<ContextType>;

--- a/db/prisma/schema.prisma
+++ b/db/prisma/schema.prisma
@@ -43,6 +43,7 @@ model CommentUpvote {
   updatedAt DateTime  @updatedAt
   deletedAt DateTime?
 
+  @@unique([commentID, userID])
   @@index([commentID])
   @@index([userID])
 }

--- a/packages/gql-utils/data-loader/create-data-loader.ts
+++ b/packages/gql-utils/data-loader/create-data-loader.ts
@@ -7,8 +7,6 @@ export function createDataLoader<TKey, TValue>(
   return new DataLoader(async (keys: readonly TKey[]) => {
     const result = (await batchFn(keys)) ?? [];
 
-    console.log({ result });
-
     onComplete?.(result as unknown as TValue[]);
 
     return result;

--- a/packages/gql-utils/data-loader/create-data-loader.ts
+++ b/packages/gql-utils/data-loader/create-data-loader.ts
@@ -1,5 +1,16 @@
 import DataLoader, { type BatchLoadFn } from "dataloader";
 
-export function createDataLoader<T, U>(batchFn: BatchLoadFn<T, U>) {
-  return new DataLoader(batchFn);
+export function createDataLoader<TKey, TValue>(
+  batchFn: BatchLoadFn<TKey, TValue>,
+  onComplete?: (values: TValue[]) => void
+) {
+  return new DataLoader(async (keys: readonly TKey[]) => {
+    const result = (await batchFn(keys)) ?? [];
+
+    console.log({ result });
+
+    onComplete?.(result as unknown as TValue[]);
+
+    return result;
+  });
 }

--- a/packages/gql-utils/data-loader/create-data-loader.ts
+++ b/packages/gql-utils/data-loader/create-data-loader.ts
@@ -1,0 +1,5 @@
+import DataLoader, { type BatchLoadFn } from "dataloader";
+
+export function createDataLoader<T, U>(batchFn: BatchLoadFn<T, U>) {
+  return new DataLoader(batchFn);
+}

--- a/packages/gql-utils/data-loader/index.ts
+++ b/packages/gql-utils/data-loader/index.ts
@@ -1,0 +1,1 @@
+export * from "./create-data-loader"

--- a/packages/gql-utils/index.ts
+++ b/packages/gql-utils/index.ts
@@ -1,1 +1,2 @@
+export * from "./data-loader";
 export * from "./prisma";


### PR DESCRIPTION
Adds a new simple wrapper around `DataLoader` so apps don't use it directly, which gives us a solid extension for the future.

Used this loader, it's not optimized by us, because we delegate it to prisma's own dataloader abstaction by using `prisma.upvote.findUnique`: https://www.prisma.io/docs/guides/performance-and-optimization/query-optimization-performance#solving-n1-in-graphql-with-findunique-and-prismas-dataloader

### Checklist

- [x] discord username: `umut`
- [x] Closes #621 
- [x] Closes #623 
- [ ] PR must be created for an issue from issues under "In progress" column from [our project board](https://github.com/orgs/kamp-us/projects/2/views/1).
- [ ] A descriptive and understandable title: The PR title should clearly describe the nature and purpose of the changes. The PR title should be the first thing displayed when the PR is opened. And it should follow the semantic commit rules, and should include the app/package/service name in the title. For example, a title like "docs(@kampus-apps/pano): Add README.md" can be used.
- [ ] Related file selection: Only relevant files should be touched and no other files should be affected.
- [ ] I ran `npx turbo run` at the root of the repository, and build was successful.
- [ ] I installed the npm packages using `npm install --save-exact <package>` so my package is pinned to a specific npm version. Leave empty if no package was installed. Leave empty if no package was installed with this PR.

### How were these changes tested?

Please describe the tests you did to test the changes you made. Please also specify your test configuration.
