### PR TITLE
fix(@kampus/relay): attach ssr next-auth cookies to fetch req

### DIFF
--- a/apps/gql/app/graphql/route.ts
+++ b/apps/gql/app/graphql/route.ts
@@ -1,6 +1,5 @@
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { type NextApiRequest, type NextApiResponse } from "next";
 import { createSchema, createYoga } from "graphql-yoga";
 
 import { getServerSession } from "@kampus/next-auth";
@@ -14,16 +13,14 @@ import { type KampusGQLContext } from "~/schema/types";
 const typeDefs = readFileSync(join(process.cwd(), "schema/schema.graphql"), "utf8").toString();
 const clients = createClients();
 
-type ServerContext = { req: NextApiRequest; res: NextApiResponse } & KampusGQLContext;
-
-const { handleRequest } = createYoga<ServerContext>({
-  schema: createSchema<ServerContext>({ typeDefs, resolvers }),
+const { handleRequest } = createYoga<KampusGQLContext>({
+  schema: createSchema<KampusGQLContext>({ typeDefs, resolvers }),
   logging: "debug",
   graphiql: true,
-  context: async ({ req, res }) => {
+  context: async () => {
     const loaders = createLoaders(clients);
     const actions = createActions(clients);
-    const session = await getServerSession(req, res);
+    const session = await getServerSession();
 
     return {
       loaders,

--- a/package-lock.json
+++ b/package-lock.json
@@ -25212,6 +25212,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
+        "@kampus/std": "*",
         "react-relay": "15.0.0",
         "relay-runtime": "15.0.0"
       },

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -11,6 +11,7 @@
     "extends": "../../package.json"
   },
   "dependencies": {
+    "@kampus/std": "*",
     "react-relay": "15.0.0",
     "relay-runtime": "15.0.0"
   },

--- a/packages/std/index.ts
+++ b/packages/std/index.ts
@@ -1,1 +1,2 @@
 export * from "./assert-never";
+export * from "./dictionary";


### PR DESCRIPTION
Attach cookies to serverside next.js fetch requests to our gql server. browser does this automatically, but we need to do that manually at server.