### PR TITLE
fix(pano): remove `pano` from site link route

### DIFF
--- a/apps/kampus/app/pano/features/post-list/PostItem.tsx
+++ b/apps/kampus/app/pano/features/post-list/PostItem.tsx
@@ -93,7 +93,7 @@ export const PostItem = (props: PostItemProps) => {
           </div>
 
           <div className="text-muted-foreground flex items-center gap-1 text-sm">
-            <Link className="text-sm" href={post.site ? "pano/site/" + post.site : ""}>
+            <Link className="text-sm" href={post.site ? "site/" + post.site : ""}>
               {post.site ?? ""}
             </Link>
           </div>

--- a/apps/kampus/app/pano/features/post-list/PostItem.tsx
+++ b/apps/kampus/app/pano/features/post-list/PostItem.tsx
@@ -93,7 +93,7 @@ export const PostItem = (props: PostItemProps) => {
           </div>
 
           <div className="text-muted-foreground flex items-center gap-1 text-sm">
-            <Link className="text-sm" href={post.site ? "site/" + post.site : ""}>
+            <Link className="text-sm" href={post.site ? "/site/" + post.site : ""}>
               {post.site ?? ""}
             </Link>
           </div>


### PR DESCRIPTION
# Description

Fixes the posts by site page route problem in the deployed version