### PR TITLE
fix(ci): remove test config from packages without tests

### DIFF
--- a/apps/pasaport/package.json
+++ b/apps/pasaport/package.json
@@ -6,20 +6,13 @@
     "build": "next build",
     "dev": "next dev -p 3001",
     "start": "next start",
-    "lint": "next lint",
-    "test": "vitest",
-    "test:ui": "vitest --ui",
-    "test:cov": "vitest --coverage"
+    "lint": "next lint"
   },
   "volta": {
     "extends": "../../package.json"
   },
   "devDependencies": {
-    "@vitest/coverage-v8": "0.32.2",
-    "@vitest/ui": "0.32.2",
-    "vite-tsconfig-paths": "4.2.0",
-    "vitest": "0.32.2",
-    "vitest-mock-extended": "1.1.3"
+    "vite-tsconfig-paths": "4.2.0"
   },
   "dependencies": {
     "znv": "0.3.2",

--- a/apps/pasaport/vitest.config.ts
+++ b/apps/pasaport/vitest.config.ts
@@ -1,6 +1,0 @@
-import tsconfigPaths from "vite-tsconfig-paths";
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-  plugins: [tsconfigPaths()],
-});

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,11 +104,7 @@
         "zod": "3.21.4"
       },
       "devDependencies": {
-        "@vitest/coverage-v8": "0.32.2",
-        "@vitest/ui": "0.32.2",
-        "vite-tsconfig-paths": "4.2.0",
-        "vitest": "0.32.2",
-        "vitest-mock-extended": "1.1.3"
+        "vite-tsconfig-paths": "4.2.0"
       }
     },
     "apps/studio": {
@@ -25275,11 +25271,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "devDependencies": {
-        "@vitest/coverage-v8": "0.32.2",
-        "@vitest/ui": "0.32.2",
-        "vite-tsconfig-paths": "4.2.0",
-        "vitest": "0.32.2",
-        "vitest-mock-extended": "1.1.3"
+        "vite-tsconfig-paths": "4.2.0"
       }
     },
     "packages/tailwind": {

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -4,23 +4,12 @@
   "description": "",
   "main": "index.ts",
   "types": "index.ts",
-  "scripts": {
-    "test": "vitest",
-    "test:ui": "vitest --ui",
-    "test:cov": "vitest --coverage"
-  },
   "author": "",
   "license": "MIT",
   "volta": {
     "extends": "../../package.json"
   },
-  "dependencies": {
-  },
   "devDependencies": {
-    "@vitest/coverage-v8": "0.32.2",
-    "@vitest/ui": "0.32.2",
-    "vite-tsconfig-paths": "4.2.0",
-    "vitest": "0.32.2",
-    "vitest-mock-extended": "1.1.3"
+    "vite-tsconfig-paths": "4.2.0"
   }
 }

--- a/packages/std/vitest.config.ts
+++ b/packages/std/vitest.config.ts
@@ -1,6 +1,0 @@
-import tsconfigPaths from "vite-tsconfig-paths";
-import { defineConfig } from "vitest/config";
-
-export default defineConfig({
-  plugins: [tsconfigPaths()],
-});


### PR DESCRIPTION
# Description

- Removed vitest configuration from workspaces without tests (`apps/pasaport` and `packages/std`)
- Removed vitest dependencies from `package.json` of workspaces without tests  (`apps/pasaport` and `packages/std`)
- Removed testing related `script` definitions from `package.json` of workspaces without tests  (`apps/pasaport` and `packages/std`)
- Updated `package-lock.json` of the repository

### Checklist

- [x] discord username: `muroyoe#9144`
- [x] Closes #663
- [ ] PR must be created for an issue from issues under "In progress" column from [our project board](https://github.com/orgs/kamp-us/projects/2/views/1).
- [x] A descriptive and understandable title: The PR title should clearly describe the nature and purpose of the changes. The PR title should be the first thing displayed when the PR is opened. And it should follow the semantic commit rules, and should include the app/package/service name in the title. For example, a title like "docs(@kampus-apps/pano): Add README.md" can be used.
- [x] Related file selection: Only relevant files should be touched and no other files should be affected.
- [x] I ran `npx turbo run` at the root of the repository, and build was successful.
- [x] I installed the npm packages using `npm install --save-exact <package>` so my package is pinned to a specific npm version. Leave empty if no package was installed. Leave empty if no package was installed with this PR.

### How were these changes tested?

Listed test files in the repository:
```
$ fd ".*.test.*"                                                                                                              
apps/gql/features/pano/utils/get-sitename.test.ts
apps/gql/features/relay/pagination.test.ts
apps/gql/loaders/sozluk.test.ts
apps/gql/loaders/user.test.ts
apps/gql/loaders/utils/loader-key.test.ts
apps/gql/vitest.config.ts
apps/pasaport/vitest.config.ts
packages/gql-utils/global-id/global-id.test.ts
packages/gql-utils/prisma/connection-key.test.ts
packages/gql-utils/prisma/create-connection-loader.test.ts
packages/gql-utils/prisma/create-count-loader.test.ts
packages/gql-utils/prisma/create-loader.test.ts
packages/gql-utils/vitest.config.ts
packages/std/vitest.config.ts
```

Then also listed `package.json` files that contains `vitest`:
```
$ rg -l vitest -g "package.json"
apps/gql/package.json
apps/pasaport/package.json
packages/gql-utils/package.json
packages/std/package.json
```

Both `apps/pasaport` and `packages/std` packages contain test configuration but have no tests. So removed the test configuration and updated the `package-lock.json`
