### PR TITLE
feat(ci): Add test step to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,13 +36,14 @@ jobs:
       - name: Setup Node.js environment
         uses: actions/setup-node@v3
         with:
+          cache: npm
           node-version-file: "package.json"
 
       - name: Install dependencies
-        run: npm install
+        run: npm ci
+
+      - name: Test
+        run: npm run test:nowatch --workspaces --if-present
 
       - name: Build
         run: npm run build
-
-      # - name: Test
-      #   run: npm run test

--- a/apps/gql/package.json
+++ b/apps/gql/package.json
@@ -10,7 +10,8 @@
     "lint": "next lint",
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "test:cov": "vitest --coverage"
+    "test:cov": "vitest --coverage",
+    "test:nowatch": "vitest run"
   },
   "volta": {
     "extends": "../../package.json"

--- a/packages/gql-utils/package.json
+++ b/packages/gql-utils/package.json
@@ -7,7 +7,8 @@
   "scripts": {
     "test": "vitest",
     "test:ui": "vitest --ui",
-    "test:cov": "vitest --coverage"
+    "test:cov": "vitest --coverage",
+    "test:nowatch": "vitest run"
   },
   "author": "",
   "license": "MIT",


### PR DESCRIPTION
# Description

- Adds `test:nowatch` script to packages containing tests for running vitest without watching files. `vitest` command runs tests in `watch` mode, so it waits for file changes. This is undesirable for CI, hence, the `test:nowatch` script.
- Adds `cache: npm` arg to setup step for caching npm installs in CI jobs. Doesn't effect the testing, but a nice addition to cache npm installs to speed up CI for subsequent runs.
- Added test step before build step for early fail in CI before build step. Build takes longer to finish, but tests are much faster. It would be good idea to get feedback about the tests without waiting for the build.

**NOTE:** Related to task #663, so [this PR](https://github.com/kamp-us/monorepo/pull/702) should be merged first. It is not a blocker, but this PR runs tests only for `apps/gql` and `packages/gql-utils` as the `test:nowatch` was only added to those packages. The other packages containing test configuration will be removed after the PR since they don't have tests.

### Checklist

- [x] discord username: `muroyoe#9144`
- [x] Closes #664 
- [ ] PR must be created for an issue from issues under "In progress" column from [our project board](https://github.com/orgs/kamp-us/projects/2/views/1).
- [x] A descriptive and understandable title: The PR title should clearly describe the nature and purpose of the changes. The PR title should be the first thing displayed when the PR is opened. And it should follow the semantic commit rules, and should include the app/package/service name in the title. For example, a title like "docs(@kampus-apps/pano): Add README.md" can be used.
- [x] Related file selection: Only relevant files should be touched and no other files should be affected.
- [x] I ran `npx turbo run` at the root of the repository, and build was successful.
- [x] I installed the npm packages using `npm install --save-exact <package>` so my package is pinned to a specific npm version. Leave empty if no package was installed. Leave empty if no package was installed with this PR.

### How were these changes tested?

After the changes, I triggered the CI pipeline in my fork. See [here](https://github.com/mcanueste/monorepo/actions/runs/6606490211) for the pipeline outputs.

