### PR TITLE
fix(ci): remove unused dev deps from pasaport and std pkgs

### DIFF
--- a/apps/pasaport/package.json
+++ b/apps/pasaport/package.json
@@ -11,9 +11,6 @@
   "volta": {
     "extends": "../../package.json"
   },
-  "devDependencies": {
-    "vite-tsconfig-paths": "4.2.0"
-  },
   "dependencies": {
     "znv": "0.3.2",
     "zod": "3.21.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -102,9 +102,6 @@
         "@kampus/next-auth": "*",
         "znv": "0.3.2",
         "zod": "3.21.4"
-      },
-      "devDependencies": {
-        "vite-tsconfig-paths": "4.2.0"
       }
     },
     "apps/studio": {
@@ -25269,10 +25266,7 @@
     "packages/std": {
       "name": "@kampus/std",
       "version": "0.0.0",
-      "license": "MIT",
-      "devDependencies": {
-        "vite-tsconfig-paths": "4.2.0"
-      }
+      "license": "MIT"
     },
     "packages/tailwind": {
       "name": "@kampus/tailwind",

--- a/packages/std/package.json
+++ b/packages/std/package.json
@@ -8,8 +8,5 @@
   "license": "MIT",
   "volta": {
     "extends": "../../package.json"
-  },
-  "devDependencies": {
-    "vite-tsconfig-paths": "4.2.0"
   }
 }


### PR DESCRIPTION
# Description

- Removed unused dev dependency `vite-tsconfig-paths` from `packages/std` and `apps/pasaport`
- See comments on this PR for more detail https://github.com/kamp-us/monorepo/pull/702

### Checklist

- [x] discord username: `muroyoe#9144`
- [x] Closes #663 (see also #702)
- [x] PR must be created for an issue from issues under "In progress" column from [our project board](https://github.com/orgs/kamp-us/projects/2/views/1).
- [x] A descriptive and understandable title: The PR title should clearly describe the nature and purpose of the changes. The PR title should be the first thing displayed when the PR is opened. And it should follow the semantic commit rules, and should include the app/package/service name in the title. For example, a title like "docs(@kampus-apps/pano): Add README.md" can be used.
- [x] Related file selection: Only relevant files should be touched and no other files should be affected.
- [x] I ran `npx turbo run` at the root of the repository, and build was successful.
- [x] I installed the npm packages using `npm install --save-exact <package>` so my package is pinned to a specific npm version. Leave empty if no package was installed. Leave empty if no package was installed with this PR.

### How were these changes tested?

No need for tests.
