### PR TITLE
chore: fix dal-branch, uzak-remote, depo-repo

### DIFF
--- a/content/odin/foundations/installations/command_line_basics.md
+++ b/content/odin/foundations/installations/command_line_basics.md
@@ -122,7 +122,7 @@ Bu bölüm, bu dersi kendi kendinize anlayıp anlamadığınızı kontrol etmeni
 
 Bu alanda içerikle alakalı faydalı linkler bulunmaktadır. Zorunlu değildir, ek olarak düşünülmelidir.
 
-- [The Art of Command Line adlı ingilizce repo](https://github.com/jlevy/the-art-of-command-line#readme) başlangıç için birebirdir!. Açık kaynak git deposudur. Burada birçok profesyonel ipucu mevcut!
+- [The Art of Command Line adlı ingilizce repo](https://github.com/jlevy/the-art-of-command-line#readme) başlangıç için birebirdir!. Açık kaynak git reposudur. Burada birçok profesyonel ipucu mevcut!
 - [Learn Enough Command Line to Be Dangerous](https://www.learnenough.com/command-line-tutorial) adlı çevrimiçi ingilizce kitap, komut satırında uzmanlaşmak için harika bir kaynaktır. Bölüm 1 ve 2 ücretsizdir ve komut satırı araçlarına iyi bir giriş sağlar. Kitabın geri kalanı ücretsiz değildir ve bu noktada gerçekten ihtiyacınız olandan daha fazla derinliğe iner ancak ilginizi çekerse kitabın geri kalanını satın almaktan ve okumaktan çekinmeyin.
 - [ExplainShell.com](http://explainshell.com/), özellikle garip shell komutlarının yapısını çözmek veya Bash'in nasıl çalıştığını öğrenmek istiyorsanız harika bir ingilizce kaynaktır.
 - [Unix/Linux Command Cheat Sheet adlı ingilizce cheatsheet](https://files.fosswire.com/2007/08/fwunixref.pdf), Linux kullanımına aşina olduğunuzda düzenli olarak başvurabileceğiniz önemli komutların listesini içerir. Bilgisayarınızın başında olmadığınız zamanlarda fiziksel bir kopyasını yanınızda bulundurmak için çıktısını alabilirsiniz.

--- a/content/odin/foundations/javascript_basics/DOM_manipulation_and_events.md
+++ b/content/odin/foundations/javascript_basics/DOM_manipulation_and_events.md
@@ -31,7 +31,7 @@ DOM (veya Belge Nesne Modeli), bir web sayfasının içeriğinin ağaç benzeri 
 ```
 
 
-Yukarıdaki örnekte `<div class="display"></div>`, `<div id="container"></div>`'nin bir "çocuğu" ve `<div class="controls"></div>`'nin bir kardeşidir. Bunu bir aile ağacı gibi düşünün. `<div id="container"></div>` bir **ebeveyn**dir, **çocukları** bir sonraki seviyede, her biri kendi "dalında(branch)" yer alır.
+Yukarıdaki örnekte `<div class="display"></div>`, `<div id="container"></div>`'nin bir "çocuğu" ve `<div class="controls"></div>`'nin bir kardeşidir. Bunu bir aile ağacı gibi düşünün. `<div id="container"></div>` bir **ebeveyn**dir, **çocukları** bir sonraki seviyede, her biri kendi "branch'inde" yer alır.
 
 ### Seçicilerle düğümleri hedefleme
 

--- a/content/odin/foundations/javascript_basics/project_rock_paper_scissors.md
+++ b/content/odin/foundations/javascript_basics/project_rock_paper_scissors.md
@@ -18,7 +18,7 @@ Son olarak, bu sizin sıfırdan oluşturduğunuz ilk JavaScript programı olduğ
 <div class="lesson-content__panel" markdown="1">
 Erken ve sık sık commit atmayı unutmayın! [Commit Mesajı dersine buradan](https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/commit-messages) bakabilirsiniz!
 
-1. Projeniz için yeni bir Git deposu oluşturun.
+1. Projeniz için yeni bir Git reposu oluşturun.
 2. Bir boş HTML belgesi oluşturun ve bir script etiketi oluşturun (İpucu: harici bir .js dosyasını kullanmak en iyi yöntemdir). Bu oyun sadece konsoldan oynanacak, bu yüzden başka bir şey hakkında endişelenmeyin.
 3. Oyununuz bilgisayara karşı oynanacak, bu yüzden rastgele 'Taş', 'Kağıt' veya 'Makas' döndürecek "getComputerChoice" adlı bir fonksiyonla başlayın. Bu fonksiyonu oyunda bilgisayarın oynaması için kullanacağız. _İpucu: bir sonraki adıma geçmeden önce bu özelliğin beklenen çıktıyı döndürdüğünden emin olmak için konsolu kullanın!_
 4. Taş Kağıt Makas'ın tek bir turunu oynayan bir fonksiyon yazın. Fonksiyon, iki parametre almalıdır - "playerSelection" ve "computerSelection" - ve ardından turun kazananını belirten bir dize döndürmelidir: `"Kaybettin! Kağıt, Taşı yener"` gibi.

--- a/content/odin/foundations/javascript_basics/revisiting_rock_paper_scissors.md
+++ b/content/odin/foundations/javascript_basics/revisiting_rock_paper_scissors.md
@@ -6,25 +6,25 @@ title: 'Taş Kağıt Makas Projesine Geri Dönüş'
 
 Şimdi DOM'u manipüle edebildiğimize göre, [Taş Kağıt Makas](https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/rock-paper-scissors) oyununu tekrar gözden geçirme ve basit bir kullanıcı arayüzü ekleme zamanı geldi.
 
-Taş Kağıt Makas projenizde değişiklik yapmaya başlamadan önce, mevcut çalışmanızı bozmadan değişiklikler yapabilmeniz için Git'te bir kavram olan **dallanma** (branching) hakkında bilgi edinmeniz gerekli.
+Taş Kağıt Makas projenizde değişiklik yapmaya başlamadan önce, mevcut çalışmanızı bozmadan değişiklikler yapabilmeniz için Git'te bir kavram olan **branching** hakkında bilgi edinmeniz gerekli.
 
-Git'teki dallar, depo dosyalarınızın birden çok *alternatif gerçeklik* sürümünü aynı anda tutmasına olanak sağlar. Aslında (bir nevi) ilk commitinizi yaptığınızdan beri dalları kullanıyorsunuz, sadece bunu bilmiyor olabilirsiniz! [Git kurulumu](https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/setting-up-git) dersinde `git config --global init.defaultBranch main` komutunu çalıştırdığınızda, repolarınız için *varsayılan* dal olarak adlandırılan dalın adını ayarlamıştınız. Varsayılan dal, bir projede ilk commiti yaptığınızda oluşturulan daldır ve bu komutta dal adını, mevcut standartta olduğu gibi, `main` olarak ayarlarız.
+Git'teki branch'ler, repo dosyalarınızın birden çok *alternatif gerçeklik* sürümünü aynı anda tutmasına olanak sağlar. Aslında (bir nevi) ilk commitinizi yaptığınızdan beri branch'leri kullanıyorsunuz, sadece bunu bilmiyor olabilirsiniz! [Git kurulumu](https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/setting-up-git) dersinde `git config --global init.defaultBranch main` komutunu çalıştırdığınızda, repolarınız için *varsayılan* branch olarak adlandırılan branch'in adını ayarlamıştınız. Varsayılan branch, bir projede ilk commiti yaptığınızda oluşturulan branch'dir ve bu komutta branch adını, mevcut standartta olduğu gibi, `main` olarak ayarlarız.
 
-Bir ağacın dalları gibi (adı buradan gelir), bir projenin tüm dalları da bir "gövdeden" (`main` dal) veya *diğer* dallardan çıkar.
+Bir ağacın dalları(kelime anlamı buradan gelir) gibi, bir projenin tüm branch'leri de bir "gövdeden" (`main` branch) veya *diğer* branch'lerden çıkar.
 
-Belirli bir dalda commit yaptığınızda, değişiklikler yalnızca **bu** dalda var olur ve diğer tüm dalları, onlardan ayrıldığınızdaki haliyle bırakır.
+Belirli bir branch'de commit yaptığınızda, değişiklikler yalnızca **bu** branch'de var olur ve diğer tüm branch'leri, onlardan ayrıldığınızdaki haliyle bırakır.
 
-Bu, `main` dalınızı yalnızca düzgün çalıştığını bildiğiniz bitmiş özellikler için tutabileceğiniz ve her özelliği, *özellik (feature) dalları* olarak adlandırdığımız dalları kullanarak projenize ekleyebileceğiniz anlamına gelir.
+Bu, `main` branch'inizi yalnızca düzgün çalıştığını bildiğiniz bitmiş özellikler için bir yer olarak tutabileceğiniz ve her yeni özelliği *özellik branch'leri* olarak adlandırdığımız özel branch`leri kullanarak projenize ekleyebileceğiniz anlamına gelir.
 
-### Dalları kullanma
+### Branch'leri kullanmak
 
-`git branch <branch_name>` komutunu kullanarak yeni dallar oluşturabilirsiniz. Daha sonra `git checkout <branch_name>` komutunu kullanarak yeni dala geçiş yapabilirsiniz. Ayrıca `git checkout -b <branch_name>` şeklinde, `checkout` ile birlikte `-b` etiketini kullanarak, tek bir komutla yeni bir dal oluşturup bu dala geçebilirsiniz.
+`git branch <branch_name>` komutunu kullanarak yeni branch oluşturabilirsiniz. Daha sonra `git checkout <branch_name>` komutunu kullanarak yeni branch'e geçiş yapabilirsiniz. Ayrıca `git checkout -b <branch_name>` şeklinde, `checkout` ile birlikte `-b` etiketini kullanarak, tek bir komutla yeni bir branch oluşturup bu branch'e geçebilirsiniz.
 
-Başka hiçbir argüman olmadan `git branch` kullanarak mevcut tüm dallarınızı görebilirsiniz. Şu anda üzerinde bulunduğunuz dal bir yıldız işareti (*) ile gösterilecektir. Başka bir daldan `main` dalına geri dönmek isterseniz, `git checkout main` komutunu kullanarak başka bir dala geçer gibi geçebilirsiniz.
+Başka hiçbir argüman olmadan `git branch` kullanarak mevcut tüm branch'lerinizi görebilirsiniz. Şu anda üzerinde bulunduğunuz branch bir yıldız işareti (*) ile gösterilecektir. Başka bir branch'den `main` branch'ine geri dönmek isterseniz, `git checkout main` komutunu kullanarak başka bir branch'e geçer gibi geçebilirsiniz.
 
-Özellik dalınız üzerinde çalışmayı tamamladığınızda ve bu dalda yaptığınız commitleri ana (main) dalınıza taşımaya hazır olduğunuzda, `birleştirme (merge)` olarak bilinen işlemi gerçekleştirmeniz gerekecektir.
+Özellik branch'iniz üzerinde çalışmayı tamamladığınızda ve bu branch'de yaptığınız commitleri main branch'ine taşımaya hazır olduğunuzda, `merge(birleştirme)` olarak bilinen işlemi gerçekleştirmeniz gerekecektir.
 
-Birleştirmeler `git merge <branch_name>` komutu kullanılarak yapılır, bu komut `branch_name`'de yaptığınız commitleri alır ve o anda üzerinde bulunduğunuz dala ekler. Aşağıdaki diyagramda bir `develop` dalının oluşturulduğu, commit edildiği ve ardından `main` ile birleştirildiği bir örnek görebilirsiniz.
+Merge'ler `git merge <branch_name>` komutu kullanılarak yapılır, bu komut `branch_name`'de yaptığınız commitleri alır ve o anda üzerinde bulunduğunuz branch'e ekler. Aşağıdaki diyagramda bir `develop` branch'inin oluşturulduğu, commit edildiği ve ardından `main` ile merge'lendiği bir örnek görebilirsiniz.
 
 <pre class="mermaid">
 ---
@@ -41,40 +41,40 @@ gitGraph
    merge develop id: "merge to main"
 </pre>
 
-Bazen bir dosyadaki aynı satırlar iki farklı dal tarafından değiştirilmiş olabilir. Bu durumda, bu dalları birleştirmeye çalıştığınızda bir birleştirme çakışması (merge conflict) yaşarsınız. Dalları birleştirmek için önce çakışmayı çözmeniz gerekecektir, bu da gelecek bir derste ele alınacaktır.
+Bazen bir dosyadaki aynı satırlar iki farklı branch tarafından değiştirilmiş olabilir. Bu durumda, bu branch'leri merge'lemeye çalıştığınızda bir merge conflict(çakışma) yaşarsınız. Branch'leri merge'lemek için önce çakışmayı çözmeniz gerekecektir, bu da gelecek bir derste ele alınacaktır.
 
-Bir dala artık ihtiyacınız olmadığında, eğer dal `main` ile birleştirildiyse `git branch -d <branch_name>` kullanılarak, birleştirilmediyse `git branch -D <branch_name>` kullanılarak silinebilir. Dallarla işiniz bittiğinde onları genellikle silmek istersiniz, aksi takdirde dallar birikerek ihtiyaç duyduğunuzda aradığınız dalı bulmanızı zorlaştırabilir.
+Bir branch'e artık ihtiyacınız olmadığında, eğer branch `main` ile merge'lendiyse `git branch -d <branch_name>` kullanılarak, merge'lenmediyse `git branch -D <branch_name>` kullanılarak silinebilir. Branch'lerle işiniz bittiğinde onları genellikle silmek istersiniz, aksi takdirde branch'ler birikerek ihtiyaç duyduğunuzda aradığınız branch'i bulmanızı zorlaştırabilir.
 
 ### Kod paylaşımı
 
-Dalların kullanımı için bir başka durum da, ana dalınıza (veya özellik dalınıza) hiç commitlemek istemediginiz kodu başkalarıyla paylaşmaktır.
+Branch'lerin kullanımı için bir başka durum da, main branch'inize (veya özellik branch'inize) hiç commitlemek istemediginiz kodu başkalarıyla paylaşmaktır.
 
-Örneğin: üzerinde çalıştığınız yeni bir özellikte çözemediğiniz bir hata varsa ve kodunuzun bozulmasına neden oluyorsa, bu bozuk kodu commitleyip projenizin "kalıcı kaydında" olmasını istemezsiniz. Bunun yerine yeni bir geçici dal oluşturabilir, ona geçebilir ve kodunuzu bu yeni dala commitleyebilirsiniz. Daha sonra bu yeni geçici dalı GitHub'a gönderirseniz, sorununuzu çözmenize yardımcı olabilecek diğer kişilerle paylaşabilirsiniz. Aşağıdaki ödevde yeni dallar oluşturma konusunda bazı uygulamalı pratikler yapacaksınız.
+Örneğin: üzerinde çalıştığınız yeni bir özellikte çözemediğiniz bir hata varsa ve kodunuzun bozulmasına neden oluyorsa, bu bozuk kodu commitleyip projenizin "kalıcı kaydında" olmasını istemezsiniz. Bunun yerine yeni bir geçici branch oluşturabilir, ona geçebilir ve kodunuzu bu yeni branch'e commit'leyebilirsiniz. Daha sonra bu yeni geçici branch'i GitHub'a gönderirseniz, sorununuzu çözmenize yardımcı olabilecek diğer kişilerle paylaşabilirsiniz. Aşağıdaki ödevde yeni branch'ler oluşturma konusunda bazı uygulamalı pratikler yapacaksınız.
 
 ### Ödev
 
 <div class="lesson-content__panel" markdown="1">
 
-1. Önceki Taş Kağıt Makas deponuzda yeni bir dal oluşturun
-    1. Taş Kağıt Makas oyunumuz için bir kullanıcı arayüzü yapacağımızdan, yeni bir dal oluşturun ve `git checkout -b rps-ui` komutuyla bu dala geçin.
-    2. Artık yerel olarak `rps-ui` dalında çalışıyorsunuz. Ancak, bu dal henüz uzak deponuzda mevcut değil. Github repo sayfanıza giderseniz, sadece 1 dalınız olduğunu ve onun da `main` olduğunu göreceksiniz. Bu yeni dalı `git push origin rps-ui` komutu ile uzak deponuza gönderin. Şimdi, GitHub deponuzda iki dal göreceksiniz! Aşağıdaki ekran görüntüsünde gösterilen açılır menüyü kullanarak GitHub'daki yeni dalı seçebilirsiniz.
+1. Önceki Taş Kağıt Makas reponuzda yeni bir branch oluşturun
+    1. Taş Kağıt Makas oyunumuz için bir kullanıcı arayüzü yapacağımızdan, yeni bir branch oluşturun ve `git checkout -b rps-ui` komutuyla bu branch'e geçin.
+    2. Artık yerel olarak `rps-ui` branch'inde çalışıyorsunuz. Ancak, bu branch henüz remote reponuzda mevcut değil. Github repo sayfanıza giderseniz, sadece 1 branch'iniz olduğunu ve onun da `main` olduğunu göreceksiniz. Bu yeni branch'i `git push origin rps-ui` komutu ile remote repo'nuza gönderin. Şimdi, GitHub repo'nuzda iki branch göreceksiniz! Aşağıdaki ekran görüntüsünde gösterilen açılır menüyü kullanarak GitHub'daki yeni branch'i seçebilirsiniz.
 
-         ![Github'da dalların bulunduğu açılır menü](https://cdn.statically.io/gh/TheOdinProject/curriculum/46c18d8445051e016b1e415fe0227a0fa33cc825/foundations/javascript_basics/revisiting_rock_paper_scissors/imgs/00.png)
+         ![Github'da branch'lerin bulunduğu açılır menü](https://cdn.statically.io/gh/TheOdinProject/curriculum/46c18d8445051e016b1e415fe0227a0fa33cc825/foundations/javascript_basics/revisiting_rock_paper_scissors/imgs/00.png)
 
-    1. `rps-ui` dalında olduğunuzdan emin olun. Bunu `git branch` komutu ile kontrol edebilirsiniz. Bulunduğunuz dalın yanında bir yıldız işareti (\*) olacaktır. Eğer herhangi bir nedenle başka bir dalda iseniz, `git checkout rps-ui` komutu ile `rps-ui` dalına geçin. Artık yeni özelliğiniz üzerinde çalışmaya hazırsınız! Not: Tıpkı ana dalda yaptığınız gibi dosya ekleyebilir, bu dala commitleyebilir ve değişiklikleri deponuza gönderebilirsiniz. Değişiklikleri yeni dalımıza gönderdiğimiz için; `git push origin main` yerine `git push origin rps-ui` kullanmanız dışında her şey aynı olacaktır.
+    1. `rps-ui` branch'inde olduğunuzdan emin olun. Bunu `git branch` komutu ile kontrol edebilirsiniz. Bulunduğunuz branch'in yanında bir yıldız işareti (\*) olacaktır. Eğer herhangi bir nedenle başka bir branch'de iseniz, `git checkout rps-ui` komutu ile `rps-ui` branch'ine geçin. Artık yeni özelliğiniz üzerinde çalışmaya hazırsınız! Not: Tıpkı ana branch'de yaptığınız gibi dosya ekleyebilir, bu branch'e commitleyebilir ve değişiklikleri reponuza gönderebilirsiniz. Değişiklikleri yeni branch'e gönderdiğimiz için; `git push origin main` yerine `git push origin rps-ui` kullanmanız dışında her şey aynı olacaktır.
 1. Kullanıcı arayüzümüzde, oyuncu cevaplarını yazmak yerine düğmelere tıklayarak oyunu oynayabilmelidir.
     1. Şimdilik, tam olarak beş tur oynanacak mantığından uzaklaşın.
     1. Her seçim için bir tane olmak üzere üç düğme oluşturun. Düğmeye her tıklandığında `playRound` fonksiyonunu doğru `playerSelection` ile çağıran bir olay dinleyicisi ekleyin (bu adım için `console.log`u kullanabilirsiniz)
     1. Sonuçları görüntülemek için bir `div` ekleyin ve tüm `console.log`larınızı DOM yöntemlerine dönüştürün.
     1. Devam eden skoru görüntüleyin ve bir oyuncu 5 puana ulaştığında oyunun galibini ilan edin.
     1. Bunun için orijinal kodunuzu yeniden düzenlemeniz (yeniden çalışmanız/yeniden yazmanız) gerekecektir. Sorun değil! Eski kodda yeniden çalışmak bir programcının hayatının önemli bir parçasıdır.
-1. Kullanıcı arayüzünüzü tamamladıktan ve her şeyin yolunda olduğundan emin olduktan sonra, tüm değişikliklerinizin `git status` ile `rps-ui` dalına commitlendiğinden emin olun.
-1. Şimdi `rps-ui` dalımızdaki değişiklikleri `main` dalımızla nasıl birleştirebileceğimize bir göz atalım.
-    1. Birleştirmek istediğimiz dala, yani `main` dalına `git checkout main` komutu ile geçiş yapın.
-    1. Şimdi `rps-ui` dalımızı `git merge rps-ui` ile mevcut dalımız olan `main` ile birleştirelim.
-    1. Her şey yolunda gittiyse, `rps-ui` dalımız artık main ile başarıyla birleştirildi! `git log` komutunu kullanarak ana dalda yaptığınız değişiklikler dışında özellik (feature)  dalında yaptığınız tüm değişiklikleri görebileceksiniz. Şimdi son adımımız için!
-    1. Şimdi `git push origin main` komutunu çalıştırarak `main` dalımızı uzak depomuzla birleştirelim. GitHub reponuza gidin ve `main` dalının `rps-ui` dalında yaptığı tüm değişiklikleri ve commitleri içerdiğini göreceksiniz. Tebrikler! İlk özelliğinizi üretim dalınıza başarıyla gönderdiniz!
-    1. Şimdi tüm kodumuz ana dalda olduğuna göre, artık `rps-ui` dalına gerçekten ihtiyacımız yok. Hem yerel hem de uzak depoda biraz temizlik yapalım. Dalı yerel depomuzdan `git branch -d rps-ui` ile silin ve ayrıca GitHub'daki uzak depodan `git push origin --delete rps-ui` ile silin. Tebrikler, temizliği tamamladık!
+1. Kullanıcı arayüzünüzü tamamladıktan ve her şeyin yolunda olduğundan emin olduktan sonra, tüm değişikliklerinizin `git status` ile `rps-ui` branch'ine commitlendiğinden emin olun.
+1. Şimdi `rps-ui` branch'indeki değişiklikleri `main` branch'imizle nasıl merge'leyeceğimize bir göz atalım.
+    1. Merge'lemek istediğimiz branch'e, yani `main` branch'ine `git checkout main` komutu ile geçiş yapın.
+    1. Şimdi `rps-ui` branch'imize `git merge rps-ui` ile mevcut branch'imiz olan `main` ile merge'leyelim.
+    1. Her şey yolunda gittiyse, `rps-ui` branch'imiz artık main ile başarıyla merge'lendi(birleştirildi) `git log` komutunu kullanarak main branch'de yaptığınız değişiklikler dışında özellik branch'inde yaptığınız tüm değişiklikleri görebileceksiniz. Şimdi son adımımız için!
+    1. Şimdi `git push origin main` komutunu çalıştırarak `main` branch'imizi remote repomuzla birleştirelim. GitHub reponuza gidin ve `main` branch'inin `rps-ui` branch'inde yaptığı tüm değişiklikleri ve commitleri içerdiğini göreceksiniz. Tebrikler! İlk özelliğinizi üretim branch'ine başarıyla gönderdiniz!
+    1. Şimdi tüm kodumuz main branch'de olduğuna göre, artık `rps-ui` branch'ine gerçekten ihtiyacımız yok. Hem yerel hem de remote repoda biraz temizlik yapalım. Branch'i yerel repomuzdan `git branch -d rps-ui` ile silin ve ayrıca GitHub'daki remote repodan `git push origin --delete rps-ui` ile silin. Tebrikler, temizliği tamamladık!
 1. Projeyi GitHub Pages'da yayınladığınızdan ve [proje dersi](https://www.theodinproject.com/paths/foundations/courses/foundations/lessons/rock-paper-scissors) bölümüne canlı önizleme bağlantısı eklediğinizden emin olun.
 
 </div>
@@ -82,6 +82,7 @@ Dalların kullanımı için bir başka durum da, ana dalınıza (veya özellik d
 ### Ek kaynaklar
 
 Bu bölüm, ilgili içeriğe yararlı bağlantılar içerir. Zorunlu değildir, tamamlayıcı olarak düşünün.
-- Andrew Peterson tarafından hazırlanan [interactive **Visual Git Cheatsheet**](https://ndpsoftware.com/git-cheatsheet.html#loc=index;) ile bu derste işlenen Git iş akışlarını aktif olarak öğrenin. Kullanacağınız çeşitli komutlara **aşina olmamanızda sorun yok**. Bunları müfredatın ilerleyen bölümlerinde öğreneceksiniz.
-- `git push -u origin <branch>` komutu ile yerel commitlerinizi uzak dallara göndermeyi **daha kolay** hale getirin. Gönderdiğiniz yerel dalı otomatik olarak uzaktaki dalla ilişkilendirir. Talha Ashar'ın [educative.io makalesini okuyun](https://www.educative.io/edpresso/what-is-the-git-push--u-remote-branch-name-command) ve basit bir `git push` komutuyla uzak bir dala daha hızlı commit yapın.
-- Peter Cottle tarafından hazırlanan bu [interaktif görselleştiriciyi](https://learngitbranching.js.org/) inceleyerek Git Dallanmasını öğrenin. Yazdığınız komutların görsel olarak sunulan ağaç dalınızı nasıl etkilediğini görürken dallanma ile ilgili önemli komutları öğrenebilirsiniz.
+
+- Andrew Peterson tarafından hazırlanan [interactive **Visual Git Cheatsheet**](https://ndpsoftware.com/git-cheatsheet.html#loc=index;) ile bu ingilizce derste işlenen Git iş akışlarını aktif olarak öğrenin. Kullanacağınız çeşitli komutlara **aşina olmamanızda sorun yok**. Bunları müfredatın ilerleyen bölümlerinde öğreneceksiniz.
+- `git push -u origin <branch>` komutu ile yerel commitlerinizi remote branch'lere göndermeyi **daha kolay** hale getirin. Gönderdiğiniz yerel branch'i otomatik olarak remote'taki branch'le ilişkilendirir. Talha Ashar'ın [educative.io ingilizce makalesini okuyun](https://www.educative.io/edpresso/what-is-the-git-push--u-remote-branch-name-command) ve basit bir `git push` komutuyla remote bir branch'e daha hızlı commit yapın.
+- Peter Cottle tarafından hazırlanan bu ingilizce [interaktif görselleştiriciyi](https://learngitbranching.js.org/) inceleyerek Git branch'lenmesini öğrenin. Yazdığınız komutların görsel olarak sunulan branch ağacınızı nasıl etkilediğini görürken, branch'lenme ile ilgili önemli komutları öğrenebilirsiniz.

--- a/content/odin/git/foundations_git/git_basics.md
+++ b/content/odin/git/foundations_git/git_basics.md
@@ -20,9 +20,9 @@ Bu bölüm, bu derste öğreneceğiniz konuların genel bir özetini içerir.
 
 #### Başlamadan önce!
 
-- Github kısa süre önce varsayılan branch (dal) adını değiştirdi. Bu yüzden git sürümünüzün yeni olduğundan emin olun (2.28 ya da sonrası). Git sürümünüzü kontrol etmek için `git --version` komutunu kullanabilirsiniz.
+- Github kısa süre önce varsayılan branch adını değiştirdi. Bu yüzden git sürümünüzün yeni olduğundan emin olun (2.28 ya da sonrası). Git sürümünüzü kontrol etmek için `git --version` komutunu kullanabilirsiniz.
 
-- Henüz yapmadıysanız, yerel varsayılan git dalınızı `main` olarak ayarlayın. Bunu yapmak için `git config --global init.defaultBranch main` komutunu kullanabilirsiniz.
+- Henüz yapmadıysanız, yerel varsayılan git branch'inizi `main` olarak ayarlayın. Bunu yapmak için `git config --global init.defaultBranch main` komutunu kullanabilirsiniz.
 
 - Master'dan main'e geçiş hakkında daha fazla bilgi için [GitHub's Renaming Repository](https://github.com/github/renaming).
 
@@ -50,7 +50,7 @@ Bu bölüm, bu derste öğreneceğiniz konuların genel bir özetini içerir.
 
    ![Clone the repo using CLI](https://cdn.statically.io/gh/TheOdinProject/curriculum/b54d14c5dcee1c6fac61aee02fca7e9ef7ba1510/foundations/git_basics/project_practicing_git_basics/imgs/04.png)
 
-7. <span id="origin-push"></span>Bu kadar! GitHub'da açtığınız reponuzu başarılı bir şekilde bilgisayarınıza bağladınız. Bunu denemek için, yeni indirilen **git_test** klasörüne `cd` komutu ile geçiş yapabilirsiniz, ardından `git remote -v` komutunu çalıştırın. Bu komut GitHub repo URL'sini gösterecektir. <span id="default-remote"></span> `git remote -v` komutunun çıktısının başında **origin** kelimesi dikkatinizi çekmiş olabilir, uzaktan bağlantınızın adını temsil eder. **Origin** ismi uzaktan repolara verilen hem varsayılan hem de geleneksel bir addır. Ama kolaylıkla "parti-papağanı" ya da "dans-eden-muz" olarakta isimlendirilebilirdi.(Şimdilik origin detaylarıyla kafanızı yormayın; bu dersin sonunda yine karşınıza çıkacak.)
+7. <span id="origin-push"></span>Bu kadar! GitHub'da açtığınız reponuzu başarılı bir şekilde bilgisayarınıza bağladınız. Bunu denemek için, yeni indirilen **git_test** klasörüne `cd` komutu ile geçiş yapabilirsiniz, ardından `git remote -v` komutunu çalıştırın. Bu komut GitHub repo URL'sini gösterecektir. <span id="default-remote"></span> `git remote -v` komutunun çıktısının başında **origin** kelimesi dikkatinizi çekmiş olabilir, remote bağlantınızın adını temsil eder. **Origin** ismi remote repolara verilen hem varsayılan hem de geleneksel bir addır. Ama kolaylıkla "parti-papağanı" ya da "dans-eden-muz" olarakta isimlendirilebilirdi.(Şimdilik origin detaylarıyla kafanızı yormayın; bu dersin sonunda yine karşınıza çıkacak.)
 
    ![Check repo remotes using CLI](https://cdn.statically.io/gh/TheOdinProject/curriculum/b54d14c5dcee1c6fac61aee02fca7e9ef7ba1510/foundations/git_basics/project_practicing_git_basics/imgs/05.png)
 
@@ -68,9 +68,9 @@ Bu bölüm, bu derste öğreneceğiniz konuların genel bir özetini içerir.
 
    ![Stage hello_world and check repo status again using CLI](https://cdn.statically.io/gh/TheOdinProject/curriculum/b54d14c5dcee1c6fac61aee02fca7e9ef7ba1510/foundations/git_basics/project_practicing_git_basics/imgs/08.png)
 
-4. <span id="git-commit"></span>Terminale `git commit -m "Add hello_world.txt"` yazın, ardından bir kez daha `git status` yazın. Göreceğiniz çıktı şu olmalıdır: "_nothing to commit, working tree clean_", bu kısaca yaptığınız değişikliklerin kaydedildiği anlamına gelir. Eğer sizin çıktınız "_upstream is gone_" gözüküyorsa, merak etmeyin. Bu normal, klonladığınız reponun başka bir dalı olmadığında gözükür. Projenin devamındaki adımları takip ettiğiniz takdirde çözülecektir.
+4. <span id="git-commit"></span>Terminale `git commit -m "Add hello_world.txt"` yazın, ardından bir kez daha `git status` yazın. Göreceğiniz çıktı şu olmalıdır: "_nothing to commit, working tree clean_", bu kısaca yaptığınız değişikliklerin kaydedildiği anlamına gelir. Eğer sizin çıktınız "_upstream is gone_" gözüküyorsa, merak etmeyin. Bu normal, klonladığınız reponun başka bir branch'i olmadığında gözükür. Projenin devamındaki adımları takip ettiğiniz takdirde çözülecektir.
 
-"_Your branch is ahead of 'origin/main' by 1 commit_" anlamı ise uzak(remote) repodaki değişikliklerinizden daha yeni" anlık görüntü"lerinizin bulunmasıdır. "Anlık görüntü"lerinizi dersin ileriki zamanlarında yükleyeceksiniz.
+"_Your branch is ahead of 'origin/main' by 1 commit_" anlamı ise remote(uzak) repodaki değişikliklerinizden daha yeni" anlık görüntü"lerinizin bulunmasıdır. "Anlık görüntü"lerinizi dersin ileriki zamanlarında yükleyeceksiniz.
 
 ![Commit hello_world and check repo status again using CLI](https://cdn.statically.io/gh/TheOdinProject/curriculum/b54d14c5dcee1c6fac61aee02fca7e9ef7ba1510/foundations/git_basics/project_practicing_git_basics/imgs/09.png)
 
@@ -112,13 +112,13 @@ Bu bölüm, bu derste öğreneceğiniz konuların genel bir özetini içerir.
 
    ![Git Log](https://cdn.statically.io/gh/TheOdinProject/curriculum/b54d14c5dcee1c6fac61aee02fca7e9ef7ba1510/foundations/git_basics/project_practicing_git_basics/imgs/17.png)
 
-#### Uzak repoya Yükleme
+#### Remote repoya Yükleme
 
 Çalışmanızı son olarak bu dersin başında oluşturduğunuz GitHub reposuna yükleyelim.
 
-1. <span id="git-push"></span> `git push` yazalım. Daha spesifik olmak gerekirse, `git push origin main` yazın. Başka bir dal (main dışında) veya farklı bir uzak repo (yukarıda bahsedildiği gibi) ile uğraşmadığınızdan, birkaç tuşa basarak bırakabilirsiniz. **NOT: Eğer bu noktada "Support for password authentication was removed on August 13, 2021.
+1. <span id="git-push"></span> `git push` yazalım. Daha spesifik olmak gerekirse, `git push origin main` yazın. Başka bir branch(main dışında) veya farklı bir remote repo (yukarıda bahsedildiği gibi) ile uğraşmadığınızdan, birkaç tuşa basarak bırakabilirsiniz. **NOT: Eğer bu noktada "Support for password authentication was removed on August 13, 2021.
    Please use a personal access token instead." şeklinde bir mesaj alırsanız, adımları yanlış takip etmişsiniz demektir ve
-   HTTPS ile değil SSH ile klonlamışsınız demektir. Lütfen [bu adımları](https://docs.github.com/en/get-started/getting-started-with-git/managing-remote-repositories#switching-remote-urls-from-https-to-ssh) takip ederek uzak bağlantınızı SSH'ye çevirin ve Github'a yüklemeyi tekrar deneyin.**
+   HTTPS ile değil SSH ile klonlamışsınız demektir. Lütfen [bu adımları](https://docs.github.com/en/get-started/getting-started-with-git/managing-remote-repositories#switching-remote-urls-from-https-to-ssh) takip ederek remote bağlantınızı SSH'ye çevirin ve Github'a yüklemeyi tekrar deneyin.**
 
    ![Push changes to remote using CLI](https://cdn.statically.io/gh/TheOdinProject/curriculum/b54d14c5dcee1c6fac61aee02fca7e9ef7ba1510/foundations/git_basics/project_practicing_git_basics/imgs/18.png)
 
@@ -140,7 +140,7 @@ Basit değişiklikler yapmaya çalışırken, örneğin README.md'deki yazım ha
 
 Bu liste en sık kullanılan Git komutlarının bir listesidir. (Bu kullanışlı sayfayı yer imlerinize eklemeyi düşünebilirsiniz.) Komutları en sonunda hepsini hatırlayabileceğiniz şekilde tanımaya çalışın:
 
-- Uzak repoyla ilgili komutlar:
+- Remote repoyla ilgili komutlar:
   - `git clone git@github.com:USER-NAME/REPOSITORY-NAME.git`
   - `git push` ya da `git push origin main` (Bu bağlamda her ikisi de aynı amaca ulaşır)
 - İş akışıyla ilgili komutlar:
@@ -192,7 +192,7 @@ Bu dersten çıkarmanız gereken temel şey **temel iş akışı**dır. Burada �
 
 Eğer bazı komutları bilmiyorsanız ya da hafızanızda kalmıyorsa endişelenmeyin. Gelecekteki Odin projelerinde bu komutları tekrar tekrar kullanırken hafızanıza kazınacaklar.
 
-İlerideki derslerde, Git'in daha gelişmiş özelliklerinden bazılarını, örneğin dalları, öğreneceğiz. Bu özellikler yeteneklerinizi daha da geliştirecek ve daha verimli olmanızı sağlayacak.
+İlerideki derslerde, Git'in daha gelişmiş özelliklerinden bazılarını, örneğin branch'leri, öğreneceğiz. Bu özellikler yeteneklerinizi daha da geliştirecek ve daha verimli olmanızı sağlayacak.
 
 Şimdilik, burada öğrendiğiniz Git'in temellerini, bundan sonra tüm projelerinizde kullanmaya odaklanın. Yakında temel Git komutlarının her birini hafızanızdan yazabileceksiniz!
 
@@ -200,16 +200,16 @@ Eğer bazı komutları bilmiyorsanız ya da hafızanızda kalmıyorsa endişelen
 
 Bu bölüm, bu dersi kendi kendinize anlayıp anlamadığınızı kontrol etmeniz için sorular içermektedir. Bir soruyu yanıtlamakta zorlanıyorsanız, soruya tıklayın ve bağlantılı olduğu materyali gözden geçirin.
 
-- [GitHub da nasıl yeni bir depo açarız ?](#repo-oluşturma)
-- [GitHub dan bilgisayarınıza nasıl depo kopyalarsınız ?](#github-to-local)
+- [GitHub da nasıl yeni bir repo açarız ?](#repo-oluşturma)
+- [GitHub dan bilgisayarınıza nasıl repo kopyalarsınız ?](#github-to-local)
 - [Bağlantınızın varsayılan adı nedir ?](#default-remote)
 - [`git push origin main` komutundaki `origin` komutunu açıklayın.](#origin-push)
 - [`git push origin main` komutundaki `main` komutunu açıklayın.](#main-push)
 - [Git'in kullandığı iki aşamalı dosya kaydetme sistemini açıklayın.](#two-stages)
-- [Bulunduğunuz depo'nun durumuna nasıl bakarsınız ?](#git-status)
+- [Bulunduğunuz repo'nun durumuna nasıl bakarsınız ?](#git-status)
 - [Git'te hazırlanma(staging) bölgesine nasıl dosya eklersiniz?](#git-add)
 - [Hazırlanma(staging) bölgesindeki dosyaları nasıl işleyip(commit) açıklayıcı bir mesaj eklersiniz ?](#git-commit)
-- [GitHub daki deponuza değişiklikleri nasıl yüklersiniz(push)?](#git-push)
+- [GitHub'daki reponuza değişiklikleri nasıl yüklersiniz(push)?](#git-push)
 - [İşlem(commit) geçmişinize nasıl bakarsınız ?](#git-log)
 
 ### Ek kaynaklar
@@ -218,4 +218,4 @@ Bu alanda içerikle alakalı faydalı linkler bulunmaktadır. Zorunlu değildir,
 
 - Kunal Kushwaha'ın [Complete Git and GitHub Tutorial adlı ingilizce videosu](https://www.youtube.com/watch?v=apGV9Kg7ics)
 - [Git - Reference adlı ingilizce git dökümantasyonu](https://git-scm.com/docs)
-- [GitHub'a yerel olarak barındırılan kod ekleme hakkındaki bu ingilizce makale](https://docs.github.com/en/migrations/importing-source-code/using-the-command-line-to-import-source-code/adding-locally-hosted-code-to-github), yerel bir klasörden git deposu oluşturma ve GitHub'a ekleme konusunda size yol gösterecektir.
+- [GitHub'a yerel olarak barındırılan kod ekleme hakkındaki bu ingilizce makale](https://docs.github.com/en/migrations/importing-source-code/using-the-command-line-to-import-source-code/adding-locally-hosted-code-to-github), yerel bir klasörden git reposu oluşturma ve GitHub'a ekleme konusunda size yol gösterecektir.

--- a/content/odin/git/foundations_git/introduction_to_git.md
+++ b/content/odin/git/foundations_git/introduction_to_git.md
@@ -14,7 +14,7 @@ Fakat Git'teki bir _kaydetme işlemi_, dosya ve klasörlerdeki farklılıkları 
 
 Müfredatımız dahilinde **yalnızca** GitHub'ı desteklediğimizi ve alternatiflerin sorunlarını gidermeye yardımcı olmayacağımızı lütfen unutmayın.
 
-<span id="git-local"></span>Git _yerel_ makinenizde çalışırken,<span id="github-remote"></span> GitHub tüm kodlama projeleriniz için web üzerinde uzak bir depolama tesisidir. Bu, Git'i öğrenerek portföyünüzü GitHub'da sergileyebileceğiniz anlamına gelir! Bu gerçekten önemli çünkü neredeyse tüm yazılım geliştirme şirketleri Git kullanmayı modern web geliştiricileri için temel bir beceri olarak görüyor. Bir GitHub portföyüne sahip olmak, gelecekteki potansiyel işverenlere neler yapabileceğinize dair kanıt sağlayacaktır.
+<span id="git-local"></span>Git _yerel_ makinenizde çalışırken,<span id="github-remote"></span> GitHub tüm kodlama projeleriniz için web üzerinde remote bir depolama tesisidir. Bu, Git'i öğrenerek portföyünüzü GitHub'da sergileyebileceğiniz anlamına gelir! Bu gerçekten önemli çünkü neredeyse tüm yazılım geliştirme şirketleri Git kullanmayı modern web geliştiricileri için temel bir beceri olarak görüyor. Bir GitHub portföyüne sahip olmak, gelecekteki potansiyel işverenlere neler yapabileceğinize dair kanıt sağlayacaktır.
 
 Bu derste Git'in tarihçesini, ne olduğunu ve ne işe yaradığını kısaca inceleyeceğiz.
 
@@ -49,8 +49,8 @@ Bu bölüm, dersi anlayıp anlamadığınızı kontrol etmeniz için sorular iç
 
 - <a class="knowledge-check-link" href="#giriş"> Git ne tür bir program </a>
 - <a class="knowledge-check-link" href="#text-editor-and-git">Git ile bir metin editörü arasında kaydettikleri ve kayıt tuttukları açısından ne gibi farklar vardır? </a>
-- <a class="knowledge-check-link" href="#git-local"> Git yerel düzeyde mi yoksa uzak düzeyde mi çalışır ? </a>
-- <a class="knowledge-check-link" href="#github-remote">Github yerel düzeyde mi yoksa uzak düzeyde mi çalışır ? </a>
+- <a class="knowledge-check-link" href="#git-local"> Git yerel düzeyde mi yoksa remote düzeyde mi çalışır ? </a>
+- <a class="knowledge-check-link" href="#github-remote">Github yerel düzeyde mi yoksa remote düzeyde mi çalışır ? </a>
 - <a class="knowledge-check-link" href="https://www.youtube.com/watch?v=2ReR1YJrNOM">Git geliştiriciler için neden önemlidir ?</a>
 - <a class="knowledge-check-link" href="https://youtu.be/1h9_cB9mPT8?t=162">Git ve GitHub neden geliştirici ekipleri için kullanışlıdır ?</a>
 


### PR DESCRIPTION
# Description

I have changed some turkish words like "dal", "uzak", "depo", "birleştirmek" to their english counterparts which they are already in use in turkish. 

dal => branch,
uzak depo => remote repo
birleştirmek => merge'lemek 